### PR TITLE
Fix pagefind update workflow

### DIFF
--- a/.github/workflows/www-apps-pagefind-bin-update.yaml
+++ b/.github/workflows/www-apps-pagefind-bin-update.yaml
@@ -22,7 +22,7 @@ env:
   epn: pagefind-bin
   description: "Static low-bandwidth search at scale"
   homepage: "https://pagefind.app"
-  github_owner: CloudCannon
+  github_owner: Pagefind
   github_repo: pagefind
   keywords: ~amd64 ~arm64
   workflow_filename: www-apps-pagefind-bin-update.yaml
@@ -53,7 +53,7 @@ jobs:
         run: |
             sudo apt-get update
             sudo apt-get install -y wget jq coreutils
-            url="$(curl -s --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/arran4/g2/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("_linux_amd64.deb"))')"
+            url="$(curl -s -L --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/arran4/g2/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("_linux_amd64.deb"))')"
             echo "$url"
             wget "${url}" -O /tmp/g2.deb
             sudo dpkg -i /tmp/g2.deb
@@ -65,7 +65,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          tags=$(curl -s -L --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then

--- a/www-apps/pagefind-bin/pagefind-bin-1.1.1.ebuild
+++ b/www-apps/pagefind-bin/pagefind-bin-1.1.1.ebuild
@@ -13,10 +13,10 @@ S="${WORKDIR}"
 
 
 SRC_URI="
-  amd64? (  https://github.com/CloudCannon/pagefind/releases/download/v1.1.1/pagefind-v1.1.1-x86_64-unknown-linux-musl.tar.gz -> ${P}-pagefind-v1.1.1-x86_64-unknown-linux-musl.tar.gz  )  
-  amd64? (  https://github.com/CloudCannon/pagefind/releases/download/v1.1.1/pagefind_extended-v1.1.1-x86_64-unknown-linux-musl.tar.gz -> ${P}-pagefind_extended-v1.1.1-x86_64-unknown-linux-musl.tar.gz  )  
-  arm64? (  https://github.com/CloudCannon/pagefind/releases/download/v1.1.1/pagefind-v1.1.1-aarch64-unknown-linux-musl.tar.gz -> ${P}-pagefind-v1.1.1-aarch64-unknown-linux-musl.tar.gz  )  
-  arm64? (  https://github.com/CloudCannon/pagefind/releases/download/v1.1.1/pagefind_extended-v1.1.1-aarch64-unknown-linux-musl.tar.gz -> ${P}-pagefind_extended-v1.1.1-aarch64-unknown-linux-musl.tar.gz  )  
+  amd64? (  https://github.com/Pagefind/pagefind/releases/download/v1.1.1/pagefind-v1.1.1-x86_64-unknown-linux-musl.tar.gz -> ${P}-pagefind-v1.1.1-x86_64-unknown-linux-musl.tar.gz  )
+  amd64? (  https://github.com/Pagefind/pagefind/releases/download/v1.1.1/pagefind_extended-v1.1.1-x86_64-unknown-linux-musl.tar.gz -> ${P}-pagefind_extended-v1.1.1-x86_64-unknown-linux-musl.tar.gz  )
+  arm64? (  https://github.com/Pagefind/pagefind/releases/download/v1.1.1/pagefind-v1.1.1-aarch64-unknown-linux-musl.tar.gz -> ${P}-pagefind-v1.1.1-aarch64-unknown-linux-musl.tar.gz  )
+  arm64? (  https://github.com/Pagefind/pagefind/releases/download/v1.1.1/pagefind_extended-v1.1.1-aarch64-unknown-linux-musl.tar.gz -> ${P}-pagefind_extended-v1.1.1-aarch64-unknown-linux-musl.tar.gz  )
 "
 
 src_unpack() {

--- a/www-apps/pagefind-bin/pagefind-bin-1.2.0.ebuild
+++ b/www-apps/pagefind-bin/pagefind-bin-1.2.0.ebuild
@@ -13,10 +13,10 @@ S="${WORKDIR}"
 
 
 SRC_URI="
-  amd64? (  https://github.com/CloudCannon/pagefind/releases/download/v1.2.0/pagefind-v1.2.0-x86_64-unknown-linux-musl.tar.gz -> ${P}-pagefind-v1.2.0-x86_64-unknown-linux-musl.tar.gz  )  
-  amd64? (  https://github.com/CloudCannon/pagefind/releases/download/v1.2.0/pagefind_extended-v1.2.0-x86_64-unknown-linux-musl.tar.gz -> ${P}-pagefind_extended-v1.2.0-x86_64-unknown-linux-musl.tar.gz  )  
-  arm64? (  https://github.com/CloudCannon/pagefind/releases/download/v1.2.0/pagefind-v1.2.0-aarch64-unknown-linux-musl.tar.gz -> ${P}-pagefind-v1.2.0-aarch64-unknown-linux-musl.tar.gz  )  
-  arm64? (  https://github.com/CloudCannon/pagefind/releases/download/v1.2.0/pagefind_extended-v1.2.0-aarch64-unknown-linux-musl.tar.gz -> ${P}-pagefind_extended-v1.2.0-aarch64-unknown-linux-musl.tar.gz  )  
+  amd64? (  https://github.com/Pagefind/pagefind/releases/download/v1.2.0/pagefind-v1.2.0-x86_64-unknown-linux-musl.tar.gz -> ${P}-pagefind-v1.2.0-x86_64-unknown-linux-musl.tar.gz  )
+  amd64? (  https://github.com/Pagefind/pagefind/releases/download/v1.2.0/pagefind_extended-v1.2.0-x86_64-unknown-linux-musl.tar.gz -> ${P}-pagefind_extended-v1.2.0-x86_64-unknown-linux-musl.tar.gz  )
+  arm64? (  https://github.com/Pagefind/pagefind/releases/download/v1.2.0/pagefind-v1.2.0-aarch64-unknown-linux-musl.tar.gz -> ${P}-pagefind-v1.2.0-aarch64-unknown-linux-musl.tar.gz  )
+  arm64? (  https://github.com/Pagefind/pagefind/releases/download/v1.2.0/pagefind_extended-v1.2.0-aarch64-unknown-linux-musl.tar.gz -> ${P}-pagefind_extended-v1.2.0-aarch64-unknown-linux-musl.tar.gz  )
 "
 
 src_unpack() {

--- a/www-apps/pagefind-bin/pagefind-bin-1.3.0.ebuild
+++ b/www-apps/pagefind-bin/pagefind-bin-1.3.0.ebuild
@@ -13,10 +13,10 @@ S="${WORKDIR}"
 
 
 SRC_URI="
-  amd64? (  https://github.com/CloudCannon/pagefind/releases/download/v1.3.0/pagefind-v1.3.0-x86_64-unknown-linux-musl.tar.gz -> ${P}-pagefind-v1.3.0-x86_64-unknown-linux-musl.tar.gz  )  
-  amd64? (  https://github.com/CloudCannon/pagefind/releases/download/v1.3.0/pagefind_extended-v1.3.0-x86_64-unknown-linux-musl.tar.gz -> ${P}-pagefind_extended-v1.3.0-x86_64-unknown-linux-musl.tar.gz  )  
-  arm64? (  https://github.com/CloudCannon/pagefind/releases/download/v1.3.0/pagefind-v1.3.0-aarch64-unknown-linux-musl.tar.gz -> ${P}-pagefind-v1.3.0-aarch64-unknown-linux-musl.tar.gz  )  
-  arm64? (  https://github.com/CloudCannon/pagefind/releases/download/v1.3.0/pagefind_extended-v1.3.0-aarch64-unknown-linux-musl.tar.gz -> ${P}-pagefind_extended-v1.3.0-aarch64-unknown-linux-musl.tar.gz  )  
+  amd64? (  https://github.com/Pagefind/pagefind/releases/download/v1.3.0/pagefind-v1.3.0-x86_64-unknown-linux-musl.tar.gz -> ${P}-pagefind-v1.3.0-x86_64-unknown-linux-musl.tar.gz  )
+  amd64? (  https://github.com/Pagefind/pagefind/releases/download/v1.3.0/pagefind_extended-v1.3.0-x86_64-unknown-linux-musl.tar.gz -> ${P}-pagefind_extended-v1.3.0-x86_64-unknown-linux-musl.tar.gz  )
+  arm64? (  https://github.com/Pagefind/pagefind/releases/download/v1.3.0/pagefind-v1.3.0-aarch64-unknown-linux-musl.tar.gz -> ${P}-pagefind-v1.3.0-aarch64-unknown-linux-musl.tar.gz  )
+  arm64? (  https://github.com/Pagefind/pagefind/releases/download/v1.3.0/pagefind_extended-v1.3.0-aarch64-unknown-linux-musl.tar.gz -> ${P}-pagefind_extended-v1.3.0-aarch64-unknown-linux-musl.tar.gz  )
 "
 
 src_unpack() {


### PR DESCRIPTION
## Summary
- update github owner since pagefind repo was moved
- follow redirects when downloading release metadata
- update pagefind-bin ebuilds to new repo URL

## Testing
- `pip install pkgcheck`
- `pkgcheck scan --net --jobs 1` *(fails: repo has missing masters)*

------
https://chatgpt.com/codex/tasks/task_e_68404bf473fc832f9dc2537492d1e2a4