### PR TITLE
Regenerate workflow builder configuration

### DIFF
--- a/current.config
+++ b/current.config
@@ -1,8 +1,8 @@
 # Config for: https://github.com/arran4/arrans_overlay_workflow_builder
-
 Type Github AppImage Release
 GithubProjectUrl https://github.com/janhq/jan/
-EbuildName jan-appimage
+Category app-misc
+EbuildName jan-appimage.ebuild
 Description Jan is an open source alternative to ChatGPT that runs 100% offline on your computer. Multiple engine support (llama.cpp, TensorRT-LLM)
 Homepage https://jan.ai/
 License GNU Affero General Public License v3.0
@@ -12,10 +12,10 @@ Icons root
 Dependencies sys-libs/glibc sys-libs/zlib
 Binary amd64=>jan-linux-x86_64-${VERSION}.AppImage > jan.AppImage
 
-
 Type Github AppImage Release
 GithubProjectUrl https://github.com/Bin-Huang/chatbox
-EbuildName chatbox-appimage
+Category app-misc
+EbuildName chatbox-appimage.ebuild
 Description User-friendly Desktop Client App for AI Models/LLMs (GPT, Claude, Gemini, Ollama...)
 Homepage https://chatboxai.app
 License GNU General Public License v3.0
@@ -26,10 +26,10 @@ Dependencies sys-libs/zlib sys-libs/glibc sys-libs/zlib sys-libs/glibc
 Binary amd64=>Chatbox.CE-${VERSION}-x86_64.AppImage > chatbox.AppImage
 Binary arm64=>Chatbox.CE-${VERSION}-arm64.AppImage > chatbox.AppImage
 
-
 Type Github AppImage Release
 GithubProjectUrl https://github.com/arran4/flutter_google_datastore
-EbuildName flutter-google-datastore-appimage
+Category dev-util
+EbuildName flutter-google-datastore-appimage.ebuild
 Description Google Datastore and Datastore emulator client for "easy" modification of values
 License unknown
 Workaround Semantic Version Prerelease Hack 1
@@ -39,10 +39,10 @@ Icons hicolor-apps root
 Dependencies sys-libs/glibc sys-libs/zlib
 Binary amd64=>flutter_google_datastore-linux-x86_64.AppImage > flutter_google_datastore.AppImage
 
-
 Type Github AppImage Release
 GithubProjectUrl https://github.com/arran4/lemmy_notify
-EbuildName lemmy-notify-appimage
+Category net-im
+EbuildName lemmy-notify-appimage.ebuild
 Description Lemmy Notification app - for desktop atm
 License unknown
 ProgramName lemmy_notify
@@ -51,11 +51,10 @@ Icons hicolor-apps root
 Dependencies sys-libs/zlib sys-libs/glibc
 Binary amd64=>lemmy_notify-linux-x86_64.AppImage > lemmy_notify.AppImage
 
-
 Type Github AppImage Release
 GithubProjectUrl https://github.com/sindresorhus/caprine
-EbuildName caprine-appimage
 Category net-im
+EbuildName caprine-appimage.ebuild
 Description Elegant Facebook Messenger desktop app
 Homepage https://sindresorhus.com/caprine
 License MIT License
@@ -65,11 +64,10 @@ Icons hicolor-apps root
 Dependencies sys-libs/glibc sys-libs/zlib
 Binary amd64=>Caprine-${VERSION}.AppImage > caprine.AppImage
 
-
 Type Github AppImage Release
 GithubProjectUrl https://github.com/rustdesk/rustdesk/
 Category net-misc
-EbuildName rustdesk-appimage
+EbuildName rustdesk-appimage.ebuild
 Description An open-source remote desktop application designed for self-hosting, as an alternative to TeamViewer.
 Homepage https://rustdesk.com
 License GNU Affero General Public License v3.0
@@ -82,11 +80,10 @@ Dependencies sys-libs/glibc sys-libs/zlib sys-libs/zlib sys-libs/glibc
 Binary amd64=>rustdesk-${TAG}-x86_64.AppImage > rustdesk.AppImage
 Binary arm64=>rustdesk-${TAG}-aarch64.AppImage > rustdesk.AppImage
 
-
 Type Github AppImage Release
 GithubProjectUrl https://github.com/localsend/localsend
-EbuildName localsend-appimage
 Category net-misc
+EbuildName localsend-appimage.ebuild
 Description An open-source cross-platform alternative to AirDrop
 Homepage https://localsend.org
 License MIT License
@@ -96,11 +93,10 @@ Icons hicolor-apps root
 Dependencies sys-libs/glibc sys-libs/zlib
 Binary amd64=>LocalSend-${VERSION}-linux-x86-64.AppImage > localsend.AppImage
 
-
 Type Github AppImage Release
 GithubProjectUrl https://github.com/WerWolv/ImHex
-EbuildName im-hex-appimage
 Category dev-util
+EbuildName im-hex-appimage.ebuild
 Description 🔍 A Hex Editor for Reverse Engineers, Programmers and people who value their retinas when working at 3 AM.
 Homepage https://imhex.werwolv.net
 License GNU General Public License v2.0
@@ -110,10 +106,10 @@ Icons pixmaps root
 Dependencies sys-libs/glibc sys-libs/zlib
 Binary amd64=>imhex-${VERSION}-x86_64.AppImage > ImHex.AppImage
 
-
 Type Github AppImage Release
 GithubProjectUrl https://github.com/LykosAI/StabilityMatrix
-EbuildName stability-matrix-appimage
+Category app-misc
+EbuildName stability-matrix-appimage.ebuild
 Description Multi-Platform Package Manager for Stable Diffusion
 Homepage https://lykos.ai
 License GNU Affero General Public License v3.0
@@ -125,7 +121,8 @@ Binary amd64=>StabilityMatrix-linux-x64.zip > StabilityMatrix.AppImage > Stabili
 
 Type Github AppImage Release
 GithubProjectUrl https://github.com/louisgv/local.ai
-EbuildName local-ai-appimage
+Category app-misc
+EbuildName local-ai-appimage.ebuild
 Description 🎒 local.ai - Run AI locally on your PC!
 Homepage https://localai.app
 License GNU General Public License v3.0
@@ -135,10 +132,10 @@ Icons hicolor-apps root
 Dependencies sys-libs/glibc sys-libs/zlib
 Binary amd64=>local-ai_${VERSION}_amd64.AppImage > local-ai.AppImage
 
-
 Type Github AppImage Release
 GithubProjectUrl https://github.com/Mobile-Artificial-Intelligence/maid
-EbuildName maid-appimage
+Category app-misc
+EbuildName maid-appimage.ebuild
 Description Maid is a cross-platform Flutter app for interfacing with GGUF / llama.cpp models locally, and with Ollama and OpenAI models remotely.
 License MIT License
 Workaround Semantic Version Without V
@@ -151,11 +148,11 @@ Binary amd64=>maid.AppImage > maid.AppImage
 Type Github AppImage Release
 GithubProjectUrl https://github.com/anyproto/anytype-ts
 Category app-text
-EbuildName anytype-ts-appimage
+EbuildName anytype-ts-appimage.ebuild
 Description Official Anytype client for MacOS, Linux, and Windows
-Workaround Semantic Version Prerelease Hack 1
 Homepage https://anytype.io
 License Other
+Workaround Semantic Version Prerelease Hack 1
 ProgramName Anytype
 DesktopFile anytype.desktop
 Icons hicolor-apps root
@@ -164,7 +161,8 @@ Binary amd64=>Anytype-${VERSION}.AppImage > Anytype.AppImage
 
 Type Github AppImage Release
 GithubProjectUrl https://github.com/ente-io/ente
-EbuildName ente-auth-appimage
+Category app-misc
+EbuildName ente-auth-appimage.ebuild
 Description Ente's 2FA solution
 Homepage https://ente.io/blog/auth/
 License GNU Affero General Public License v3.0
@@ -178,8 +176,8 @@ Binary amd64=>ente-${TAG}-x86_64.AppImage > ente_auth.AppImage
 
 Type Github Binary Release
 GithubProjectUrl https://github.com/goreleaser/goreleaser
-EbuildName goreleaser-bin
 Category dev-go
+EbuildName goreleaser-bin.ebuild
 Description Deliver Go binaries as fast and easily as possible
 Homepage https://goreleaser.com
 License MIT License
@@ -220,11 +218,10 @@ Binary arm64=>goreleaser_Linux_arm64.tar.gz > goreleaser > goreleaser
 Binary ppc64=>goreleaser_Linux_ppc64.tar.gz > goreleaser > goreleaser
 Binary x86=>goreleaser_Linux_i386.tar.gz > goreleaser > goreleaser
 
-
 Type Github Binary Release
 GithubProjectUrl https://github.com/gohugoio/hugo
-EbuildName hugo-bin
 Category www-apps
+EbuildName hugo-bin.ebuild
 Description The world’s fastest framework for building websites.
 Homepage https://gohugo.io
 License Apache License 2.0
@@ -237,10 +234,10 @@ Dependencies sys-libs/glibc sys-devel/gcc sys-libs/glibc sys-devel/gcc sys-libs/
 Binary amd64=>hugo_extended_${VERSION}_Linux-64bit.tar.gz > hugo > hugo
 Binary arm64=>hugo_extended_${VERSION}_linux-arm64.tar.gz > hugo > hugo
 
-
 Type Github Binary Release
 GithubProjectUrl https://github.com/yorukot/superfile
-EbuildName superfile-bin
+Category app-misc
+EbuildName superfile-bin.ebuild
 Description Pretty fancy and modern terminal file manager
 Homepage https://superfile.netlify.app
 License MIT License
@@ -251,7 +248,8 @@ Binary arm64=>superfile-linux-${TAG}-arm64.tar.gz > ./dist/superfile-linux-v1.1.
 
 Type Github Binary Release
 GithubProjectUrl https://github.com/mudler/LocalAI
-EbuildName local-ai-bin
+Category app-misc
+EbuildName local-ai-bin.ebuild
 Description :robot: The free, Open Source alternative to OpenAI, Claude and others. Self-hosted and local-first. Drop-in replacement for OpenAI,  running on consumer-grade hardware. No GPU required. Runs gguf, transformers, diffusers and many more models architectures. Features: Generate Text, Audio, Video, Images, Voice Cloning, Distributed inference
 Homepage https://localai.io
 License MIT License
@@ -262,11 +260,10 @@ Binary arm64=>local-ai-Linux-arm64 > local-ai
 ProgramName stablediffusion
 Binary amd64=>stablediffusion > stablediffusion
 
-
 Type Github Binary Release
 GithubProjectUrl https://github.com/CloudCannon/pagefind
-EbuildName pagefind-bin
 Category www-apps
+EbuildName pagefind-bin.ebuild
 Description Static low-bandwidth search at scale
 Homepage https://pagefind.app
 License MIT License
@@ -278,8 +275,8 @@ Binary arm64=>pagefind_extended-${TAG}-aarch64-unknown-linux-musl.tar.gz > pagef
 
 Type Github Binary Release
 GithubProjectUrl https://github.com/twpayne/chezmoi
-EbuildName chezmoi-bin
 Category app-admin
+EbuildName chezmoi-bin.ebuild
 Description Manage your dotfiles across multiple diverse machines, securely.
 Homepage https://www.chezmoi.io/
 License MIT License
@@ -303,11 +300,10 @@ Binary ppc64=>chezmoi_${VERSION}_linux_ppc64le.tar.gz > chezmoi > chezmoi
 ProgramName loong64
 Binary amd64=>chezmoi_${VERSION}_linux_loong64.tar.gz > chezmoi > chezmoi
 
-
 Type Github Binary Release
 GithubProjectUrl https://github.com/arran4/g2/
-EbuildName g2-bin
 Category app-admin
+EbuildName g2-bin.ebuild
 Description g2 Gentoo Tools
 Homepage https://wiki.gentoo.org/wiki/User:Arran4
 License unknown
@@ -317,8 +313,8 @@ Binary arm64=>g2_${VERSION}_linux_arm64.tar.gz > g2 > g2
 
 Type Github Binary Release
 GithubProjectUrl https://github.com/rusq/slackdump
-EbuildName slackdump-bin
 Category net-im
+EbuildName slackdump-bin.ebuild
 Description Save or export your private and public Slack messages, threads, files, and users locally without admin privileges.
 License GNU General Public License v3.0
 Workaround Semantic Version Prerelease Hack 1
@@ -328,8 +324,8 @@ Binary x86=>slackdump_Linux_i386.tar.gz > slackdump > slackdump
 
 Type Github Binary Release
 GithubProjectUrl https://github.com/arran4/arrans_overlay_workflow_builder
-EbuildName arrans-overlay-workflow-builder-bin
 Category app-admin
+EbuildName arrans-overlay-workflow-builder-bin.ebuild
 Description TODO
 License unknown
 ProgramName arrans_overlay_workflow_builder
@@ -339,8 +335,8 @@ Binary amd64=>arrans_overlay_workflow_builder_${VERSION}_linux_amd64.tar.gz > ov
 
 Type Github Binary Release
 GithubProjectUrl https://github.com/arran4/pimtrace
-EbuildName pimtrace-bin
 Category net-misc
+EbuildName pimtrace-bin.ebuild
 Description A CLI tool for preforming queries on ical and csv files
 License Other
 ProgramName pimtrace
@@ -360,12 +356,11 @@ Document arm64=>pimtrace_${VERSION}_linux_arm64.tar.gz > readme.MD > readme.MD
 Binary amd64=>pimtrace_${VERSION}_linux_amd64.tar.gz > csvtrace > csvtrace
 Binary arm64=>pimtrace_${VERSION}_linux_arm64.tar.gz > csvtrace > csvtrace
 
-
 Type Github Binary Release
 GithubProjectUrl https://github.com/arran4/git-tag-inc
-EbuildName git-tag-inc-bin
 Category dev-vcs
-Description Yet another semantic version incrementor and tagger for git 
+EbuildName git-tag-inc-bin.ebuild
+Description Yet another semantic version incrementor and tagger for git
 License unknown
 ProgramName git-tag-inc
 Document amd64=>git-tag-inc_${VERSION}_linux_amd64.tar.gz > readme.md > readme.md
@@ -376,10 +371,10 @@ Binary amd64=>git-tag-inc_${VERSION}_linux_amd64.tar.gz > git-tag-inc > git-tag-
 Binary arm=>git-tag-inc_${VERSION}_linux_armv7.tar.gz > git-tag-inc > git-tag-inc
 Binary arm64=>git-tag-inc_${VERSION}_linux_arm64.tar.gz > git-tag-inc > git-tag-inc
 
-
 Type Github Binary Release
 GithubProjectUrl https://github.com/arran4/podcast-cdr-manager
-EbuildName podcast-cdr-manager-bin
+Category net-misc
+EbuildName podcast-cdr-manager-bin.ebuild
 Description CLI tool to help manage podcast subscriptions for burning to CDROMs / CDR / CDRW
 License unknown
 ProgramName podcastcdrmanager
@@ -390,11 +385,10 @@ Binary amd64=>podcastcdrmanager_Linux_x86_64.tar.gz > podcastcdrmanager > podcas
 Binary arm=>podcastcdrmanager_Linux_armv6.tar.gz > podcastcdrmanager > podcastcdrmanager
 Binary arm64=>podcastcdrmanager_Linux_arm64.tar.gz > podcastcdrmanager > podcastcdrmanager
 
-
 Type Github Binary Release
 GithubProjectUrl https://github.com/arran4/editorconfig-guesser
-EbuildName editorconfig-guesser-bin
 Category dev-util
+EbuildName editorconfig-guesser-bin.ebuild
 Description Generates reasonable .editorconfig files for source files.
 License MIT License
 Document amd64=>cards_${VERSION}_linux_amd64.tar.gz > LICENSE > LICENSE
@@ -409,11 +403,10 @@ Binary amd64=>cards_${VERSION}_linux_amd64.tar.gz > ecguess > ecguess
 Binary arm=>cards_${VERSION}_linux_armv7.tar.gz > ecguess > ecguess
 Binary arm64=>cards_${VERSION}_linux_arm64.tar.gz > ecguess > ecguess
 
-
 Type Github Binary Release
 GithubProjectUrl https://github.com/arran4/mostcomm
-EbuildName mostcomm-bin
 Category app-text
+EbuildName mostcomm-bin.ebuild
 Description A cli utility for finding the most common and sorting by length, lines-sets in a text file
 License MIT License
 ProgramName mostcomm
@@ -429,10 +422,10 @@ Binary amd64=>mostcomm_${VERSION}_linux_amd64.tar.gz > mostcomm > mostcomm
 Binary arm=>mostcomm_${VERSION}_linux_armv7.tar.gz > mostcomm > mostcomm
 Binary arm64=>mostcomm_${VERSION}_linux_arm64.tar.gz > mostcomm > mostcomm
 
-
 Type Github Binary Release
 GithubProjectUrl https://github.com/arran4/anytype-to-linkwarden
-EbuildName anytype-to-linkwarden-bin
+Category app-misc
+EbuildName anytype-to-linkwarden-bin.ebuild
 Description TODO
 License unknown
 ProgramName anytype-to-linkwarden
@@ -442,10 +435,10 @@ Document arm64=>anytype-to-linkwarden_${VERSION}_linux_arm64.tar.gz > readme.md 
 Binary amd64=>anytype-to-linkwarden_${VERSION}_linux_amd64.tar.gz > anytype-to-linkwarden > anytype-to-linkwarden
 Binary arm64=>anytype-to-linkwarden_${VERSION}_linux_arm64.tar.gz > anytype-to-linkwarden > anytype-to-linkwarden
 
-
 Type Github Binary Release
 GithubProjectUrl https://github.com/Picocrypt/Picocrypt
-EbuildName picocrypt-bin
+Category app-misc
+EbuildName picocrypt-bin.ebuild
 Description A very small, very simple, yet very secure encryption tool.
 License GNU General Public License v3.0
 Workaround Semantic Version Without V
@@ -456,7 +449,8 @@ Binary amd64=>Picocrypt > Picocrypt
 # Issue discovered with this: https://github.com/arran4/arrans_overlay_workflow_builder/issues/3
 Type Github Binary Release
 GithubProjectUrl https://github.com/Byron/dua-cli
-EbuildName dua-cli-bin
+Category app-misc
+EbuildName dua-cli-bin.ebuild
 Description View disk space usage and delete unwanted data, fast.
 Homepage https://lib.rs/crates/dua-cli
 License MIT License
@@ -477,7 +471,8 @@ Binary arm64=>dua-${TAG}-aarch64-unknown-linux-musl.tar.gz > dua-v2.29.2-aarch64
 
 Type Github Binary Release
 GithubProjectUrl https://github.com/arran4/mvcommon
-EbuildName mvcommon-bin
+Category app-misc
+EbuildName mvcommon-bin.ebuild
 Description Tool for moving files into a folder where they have a common prefix
 License GNU General Public License v3.0
 ProgramName mvcommon
@@ -490,18 +485,22 @@ Binary arm64=>mvcommon_${VERSION}_linux_arm64.tar.gz > mvcommon > mvcommon
 
 Type Github Binary Release
 GithubProjectUrl https://github.com/arran4/rntocase
-EbuildName rntocase-bin
+Category app-misc
+EbuildName rntocase-bin.ebuild
 Description Some utilities to rename files, to upper, lower, title, camel, kebab, darwin case and many more
 License GNU General Public License v3.0
-ProgramName rntocase
-Document amd64=>rntocase_${VERSION}_linux_amd64.tar.gz > LICENSE > LICENSE
-Document amd64=>rntocase_${VERSION}_linux_amd64.tar.gz > LICENSE > LICENSE
+ProgramName rnacronym
+Binary amd64=>rntocase_${VERSION}_linux_amd64.tar.gz > rnacronym > rnacronym
+Binary arm64=>rntocase_${VERSION}_linux_arm64.tar.gz > rnacronym > rnacronym
 ProgramName rnreverse
 Binary amd64=>rntocase_${VERSION}_linux_amd64.tar.gz > rnreverse > rnreverse
 Binary arm64=>rntocase_${VERSION}_linux_arm64.tar.gz > rnreverse > rnreverse
 ProgramName rntocamel
 Binary amd64=>rntocase_${VERSION}_linux_amd64.tar.gz > rntocamel > rntocamel
 Binary arm64=>rntocase_${VERSION}_linux_arm64.tar.gz > rntocamel > rntocamel
+ProgramName rntocase
+Document amd64=>rntocase_${VERSION}_linux_amd64.tar.gz > LICENSE > LICENSE
+Document amd64=>rntocase_${VERSION}_linux_amd64.tar.gz > LICENSE > LICENSE
 ProgramName rntodarwin
 Binary amd64=>rntocase_${VERSION}_linux_amd64.tar.gz > rntodarwin > rntodarwin
 Binary arm64=>rntocase_${VERSION}_linux_arm64.tar.gz > rntodarwin > rntodarwin
@@ -511,38 +510,35 @@ Binary arm64=>rntocase_${VERSION}_linux_arm64.tar.gz > rntodelimited > rntodelim
 ProgramName rntokebab
 Binary amd64=>rntocase_${VERSION}_linux_amd64.tar.gz > rntokebab > rntokebab
 Binary arm64=>rntocase_${VERSION}_linux_arm64.tar.gz > rntokebab > rntokebab
+ProgramName rntolower
+Binary amd64=>rntocase_${VERSION}_linux_amd64.tar.gz > rntolower > rntolower
+Binary arm64=>rntocase_${VERSION}_linux_arm64.tar.gz > rntolower > rntolower
 ProgramName rntolowerleading
 Binary amd64=>rntocase_${VERSION}_linux_amd64.tar.gz > rntolowerleading > rntolowerleading
 Binary arm64=>rntocase_${VERSION}_linux_arm64.tar.gz > rntolowerleading > rntolowerleading
+ProgramName rntopascal
+Binary amd64=>rntocase_${VERSION}_linux_amd64.tar.gz > rntopascal > rntopascal
+Binary arm64=>rntocase_${VERSION}_linux_arm64.tar.gz > rntopascal > rntopascal
 ProgramName rntosnake
 Binary amd64=>rntocase_${VERSION}_linux_amd64.tar.gz > rntosnake > rntosnake
 Binary arm64=>rntocase_${VERSION}_linux_arm64.tar.gz > rntosnake > rntosnake
 ProgramName rntotitle
 Binary amd64=>rntocase_${VERSION}_linux_amd64.tar.gz > rntotitle > rntotitle
 Binary arm64=>rntocase_${VERSION}_linux_arm64.tar.gz > rntotitle > rntotitle
+ProgramName rntoupper
+Binary amd64=>rntocase_${VERSION}_linux_amd64.tar.gz > rntoupper > rntoupper
+Binary arm64=>rntocase_${VERSION}_linux_arm64.tar.gz > rntoupper > rntoupper
 ProgramName rntoupperleading
 Binary amd64=>rntocase_${VERSION}_linux_amd64.tar.gz > rntoupperleading > rntoupperleading
 Binary arm64=>rntocase_${VERSION}_linux_arm64.tar.gz > rntoupperleading > rntoupperleading
 ProgramName rntrim
 Binary amd64=>rntocase_${VERSION}_linux_amd64.tar.gz > rntrim > rntrim
 Binary arm64=>rntocase_${VERSION}_linux_arm64.tar.gz > rntrim > rntrim
-ProgramName rnacronym
-Binary amd64=>rntocase_${VERSION}_linux_amd64.tar.gz > rnacronym > rnacronym
-Binary arm64=>rntocase_${VERSION}_linux_arm64.tar.gz > rnacronym > rnacronym
-ProgramName rntolower
-Binary amd64=>rntocase_${VERSION}_linux_amd64.tar.gz > rntolower > rntolower
-Binary arm64=>rntocase_${VERSION}_linux_arm64.tar.gz > rntolower > rntolower
-ProgramName rntopascal
-Binary amd64=>rntocase_${VERSION}_linux_amd64.tar.gz > rntopascal > rntopascal
-Binary arm64=>rntocase_${VERSION}_linux_arm64.tar.gz > rntopascal > rntopascal
-ProgramName rntoupper
-Binary amd64=>rntocase_${VERSION}_linux_amd64.tar.gz > rntoupper > rntoupper
-Binary arm64=>rntocase_${VERSION}_linux_arm64.tar.gz > rntoupper > rntoupper
 
 Type Github Binary Release
 GithubProjectUrl https://github.com/hickford/git-credential-oauth
-EbuildName git-credential-oauth-bin
 Category dev-vcs
+EbuildName git-credential-oauth-bin.ebuild
 Description A Git credential helper that securely authenticates to GitHub, GitLab and BitBucket using OAuth.
 Homepage https://github.com/hickford/git-credential-oauth
 License MIT License
@@ -560,8 +556,8 @@ Binary x86=>git-credential-oauth_${VERSION}_linux_386.tar.gz > git-credential-oa
 
 Type Github Binary Release
 GithubProjectUrl https://github.com/veeso/termscp
-EbuildName termscp-bin
 Category net-misc
+EbuildName termscp-bin.ebuild
 Description Feature rich terminal file transfer tool
 Homepage https://termscp.veeso.dev
 License MIT License
@@ -569,4 +565,3 @@ ProgramName termscp
 Dependencies net-fs/samba sys-libs/glibc
 Binary amd64=>termscp-v\${VERSION}-x86_64-unknown-linux-gnu.tar.gz > termscp > termscp
 Binary arm64=>termscp-\${VERSION}-aarch64-unknown-linux-gnu.tar.gz > termscp > termscp
-


### PR DESCRIPTION
## Summary
- regenerate `current.config` using workflow builder library
- restore header comment and issue note
- correct categories for datastore, lemmy notify, and podcast manager

## Testing
- `pkgcheck scan --repo .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497d19b624832fbc731ff088ab6590