### PR TITLE
Fix ente-auth license

### DIFF
--- a/.github/workflows/app-misc-ente-auth-appimage-update.yaml
+++ b/.github/workflows/app-misc-ente-auth-appimage-update.yaml
@@ -26,6 +26,7 @@ env:
   github_repo: ente
   keywords: ~amd64
   workflow_filename: app-misc-ente-auth-appimage-update.yaml
+  license: "AGPL-3.0"
   ente_auth_desktop_file: 'enteauth.desktop'
   ente_auth_appimage_installed_name: 'ente_auth.AppImage'
   ente_auth_release_name_amd64: 'ente-${tag}-x86_64.AppImage'
@@ -86,7 +87,7 @@ jobs:
                 echo 'EAPI=8'
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="${{ env.license }}"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo 'IUSE=""'

--- a/app-misc/ente-auth-appimage/ente-auth-appimage-4.4.0.ebuild
+++ b/app-misc/ente-auth-appimage/ente-auth-appimage-4.4.0.ebuild
@@ -2,7 +2,7 @@
 EAPI=8
 DESCRIPTION="Ente's 2FA solution"
 HOMEPAGE="https://ente.io/blog/auth/"
-LICENSE="MIT"
+LICENSE="AGPL-3.0"
 SLOT="0"
 KEYWORDS="~amd64"
 IUSE=""


### PR DESCRIPTION
## Summary
- set license env in ente-auth workflow
- reference license variable when generating ebuilds
- update `ente-auth-appimage-4.4.0` ebuild to AGPL-3.0

## Testing
- `pkgcheck scan app-misc/ente-auth-appimage` *(fails: repo init failed: missing masters)*

------
https://chatgpt.com/codex/tasks/task_e_684e7e765950832f88f558618b90de3a