### PR TITLE
Add scheduled cleanup for duplicate ebuilds

### DIFF
--- a/.github/workflows/remove-duplicate-ebuilds.yml
+++ b/.github/workflows/remove-duplicate-ebuilds.yml
@@ -1,0 +1,40 @@
+name: Remove duplicate ebuilds
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  schedule:
+    - cron: '0 4 * * 0'
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install packaging
+
+      - name: Remove duplicate ebuilds
+        run: |
+          chmod +x ./scripts/remove_duplicate_ebuilds.py
+          ./scripts/remove_duplicate_ebuilds.py
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          branch: duplicate-ebuilds-cleanup
+          title: "Remove duplicate ebuilds"
+          commit-message: "Remove duplicate ebuilds"
+          body: |
+            This automated PR removes duplicated ebuilds that share identical content within the same slot. It keeps the newest version for each duplicate set.
+          delete-branch: true

--- a/scripts/remove_duplicate_ebuilds.py
+++ b/scripts/remove_duplicate_ebuilds.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+import os
+import re
+import hashlib
+from packaging.version import parse as parse_version
+from collections import defaultdict
+
+def parse_slot(path):
+    slot = "0"
+    try:
+        with open(path, "r", errors="ignore") as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("SLOT="):
+                    slot = line.split("=", 1)[1].strip().strip('"').strip("'")
+                    break
+    except FileNotFoundError:
+        pass
+    return slot
+
+
+def main(repo_root):
+    pattern = re.compile(r"(.+)-([0-9][^/]*)\.ebuild$")
+    groups = defaultdict(list)
+    for root, dirs, files in os.walk(repo_root):
+        for file in files:
+            if not file.endswith(".ebuild"):
+                continue
+            path = os.path.join(root, file)
+            m = pattern.match(file)
+            if not m:
+                continue
+            version = m.group(2)
+            slot = parse_slot(path)
+            with open(path, "rb") as fh:
+                digest = hashlib.md5(fh.read()).hexdigest()
+            groups[(root, slot, digest)].append((parse_version(version), path))
+    removed = []
+    for (root, slot, digest), items in groups.items():
+        if len(items) <= 1:
+            continue
+        items.sort(key=lambda x: x[0])
+        for _, p in items[:-1]:
+            os.remove(p)
+            removed.append(p)
+    if removed:
+        print("Removed duplicated ebuilds:")
+        for p in removed:
+            print(" -", p)
+    else:
+        print("No duplicates found")
+
+if __name__ == "__main__":
+    main(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))


### PR DESCRIPTION
## Summary
- add a script that removes identical ebuilds within the same slot
- add weekly workflow that runs the script and raises a pull request

## Testing
- `python3 scripts/remove_duplicate_ebuilds.py | head`


------
https://chatgpt.com/codex/tasks/task_e_6854da15216c832f968c1ac970720b8e