### PR TITLE
Add twin source ebuild

### DIFF
--- a/app-misc/twin/twin-0.9.1.ebuild
+++ b/app-misc/twin/twin-0.9.1.ebuild
@@ -1,0 +1,32 @@
+EAPI=8
+
+DESCRIPTION="Twin - a Textmode WINdow environment"
+HOMEPAGE="https://github.com/cosmos72/twin"
+SRC_URI="https://github.com/cosmos72/twin/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2 LGPL-2.1"
+SLOT="0"
+KEYWORDS="~amd64 ~x86 ~arm ~arm64"
+IUSE=""
+
+BDEPEND="virtual/pkgconfig"
+DEPEND="
+    x11-libs/libX11
+    x11-libs/libXft
+    sys-libs/ncurses
+    sys-libs/zlib
+    sys-libs/gpm
+"
+RDEPEND="${DEPEND}"
+
+src_configure() {
+    econf
+}
+
+src_compile() {
+    emake
+}
+
+src_install() {
+    default
+}


### PR DESCRIPTION
## Summary
- add a new `app-misc/twin` ebuild building twin 0.9.1 from source

## Testing
- `g2 manifest app-misc/twin` *(fails: command not found)*
- `ebuild twin-0.9.1.ebuild manifest` *(fails: command not found)*
- `pkgcheck scan --net --exit app-misc/twin` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860d48f0c74832fb3fefd24d1aa7b84