### PR TITLE
Add difftastic binary release workflow

### DIFF
--- a/.github/workflows/dev-util-difftastic-bin-update.yaml
+++ b/.github/workflows/dev-util-difftastic-bin-update.yaml
@@ -1,0 +1,145 @@
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.17 Github Binary Release current.config 2025-07-10 07:43:54.465387555 +0000 UTC m=+0.005957285
+
+name: dev-util/difftastic-bin update
+
+permissions:
+  contents: write
+
+on:
+  schedule:
+    - cron: '37 17 * * *'
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/dev-util-difftastic-bin-update.yaml'
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  ecn: dev-util
+  epn: difftastic-bin
+  description: "A structural diff that understands syntax."
+  homepage: ""
+  github_owner: Wilfred
+  github_repo: difftastic
+  keywords: ~amd64 ~arm64
+  workflow_filename: dev-util-difftastic-bin-update.yaml
+  difft_binary_installed_name: 'difft'
+  difft_binary_archived_name_amd64: 'difft'
+  difft_release_name_amd64: 'difft-\${PV}-x86_64-unknown-linux-gnu.tar.gz'
+  difft_binary_archived_name_arm64: 'difft'
+  difft_release_name_arm64: 'difft-\${PV}-aarch64-unknown-linux-gnu.tar.gz'
+
+jobs:
+  check-and-create-ebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Install required tools
+        run: |
+            sudo apt-get update
+            sudo apt-get install -y wget jq coreutils
+            url="$(curl -s --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/arran4/g2/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("_linux_amd64.deb"))')"
+            echo "$url"
+            wget "${url}" -O /tmp/g2.deb
+            sudo dpkg -i /tmp/g2.deb
+            rm /tmp/g2.deb
+
+      - name: Process each release
+        id: process_releases
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p $ebuild_dir
+          declare -A releaseTypes=()
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          for tag in $tags; do
+            version="${tag#v}"
+            if [ "${version}" = "${tag}" ]; then
+                echo "$version == $tag so there is no v removed skipping"
+                continue
+            fi
+            originalVersion="${version}"
+            if ! echo "${version}" | egrep '^([0-9]+)\.([0-9]+)(\.([0-9]+))?(-r[0-9]+)?((_)(alpha|beta|rc|p)[0-9]*)*$'; then
+                echo "tag / $version doesn't match regexp";
+                continue;
+            fi
+            releaseType="$(echo "${version}" | sed -n 's/^[^_]\+_\(alpha\|beta\|rc\|p[0-9]*\).*$/\1/p')"
+            if [[ ! -v releaseTypes[${releaseType:=release}] ]]; then
+                if [[ -v releaseTypes[release] ]]; then
+                  echo "Already have a newer main release: ${releaseTypes[release]}"
+                  continue
+                fi
+                releaseTypes[${releaseType:=release}]="${version}"
+            else
+                echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
+                continue
+            fi
+            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
+            if [ ! -f "$ebuild_file" ]; then
+
+              {
+                echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
+                echo 'EAPI=8'
+                echo "DESCRIPTION=\"${{ env.description }}\""
+                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'LICENSE="MIT"'
+                echo 'SLOT="0"'
+                echo 'KEYWORDS="${{ env.keywords }}"'
+                echo 'IUSE=""'
+                echo 'REQUIRED_USE=""'
+                echo 'DEPEND=""'
+                echo 'RDEPEND=""'
+                echo 'S="${WORKDIR}"'
+                echo ''
+                echo ''
+                echo 'SRC_URI="'
+                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/difft-\${PV}-x86_64-unknown-linux-gnu.tar.gz -> \${P}-difft-\${PV}-x86_64-unknown-linux-gnu.tar.gz  )  "
+                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/difft-\${PV}-aarch64-unknown-linux-gnu.tar.gz -> \${P}-difft-\${PV}-aarch64-unknown-linux-gnu.tar.gz  )  "
+                echo '"'
+                echo ''
+                echo 'src_unpack() {'
+                echo '  if use amd64; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-difft-\${PV}-x86_64-unknown-linux-gnu.tar.gz\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '  if use arm64; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-difft-\${PV}-aarch64-unknown-linux-gnu.tar.gz\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '}'
+                echo ''
+                echo 'src_install() {'
+                echo '  exeinto /opt/bin'
+                echo '  if use amd64; then'
+                echo '    newexe "${{ env.difft_binary_archived_name_amd64 }}" "${{ env.difft_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '  if use arm64; then'
+                echo '    newexe "${{ env.difft_binary_archived_name_arm64 }}" "${{ env.difft_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '}'
+                echo ""
+              } > $ebuild_file
+
+              # Manifest generation
+
+              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/difft-${version}-x86_64-unknown-linux-gnu.tar.gz" "${{ env.epn }}-${version}-difft-${version}-x86_64-unknown-linux-gnu.tar.gz" "${ebuild_dir}/Manifest"
+              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/difft-${version}-aarch64-unknown-linux-gnu.tar.gz" "${{ env.epn }}-${version}-difft-${version}-aarch64-unknown-linux-gnu.tar.gz" "${ebuild_dir}/Manifest"
+              echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
+            fi
+          done
+
+      - name: Commit and push changes
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          git add ./${ebuild_dir}
+          git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}" &&
+          git pull --rebase &&
+          git push || true
+        if: steps.process_releases.outputs.generated_tag

--- a/current.config
+++ b/current.config
@@ -597,3 +597,13 @@ ProgramName fq
 Binary amd64=>fq_${VERSION}_linux_amd64.tar.gz > fq > fq
 Binary arm64=>fq_${VERSION}_linux_arm64.tar.gz > fq > fq
 
+
+Type Github Binary Release
+GithubProjectUrl https://github.com/Wilfred/difftastic
+Category dev-util
+EbuildName difftastic-bin.ebuild
+Description A structural diff that understands syntax.
+License MIT
+ProgramName difft
+Binary amd64=>difft-${VERSION}-x86_64-unknown-linux-gnu.tar.gz > difft > difft
+Binary arm64=>difft-${VERSION}-aarch64-unknown-linux-gnu.tar.gz > difft > difft


### PR DESCRIPTION
## Summary
- add difftastic Github Binary Release to current.config
- generate workflow for dev-util/difftastic-bin

## Testing
- `overlay_workflow_builder_generator generate workflows -input-file current.config -output-dir output`

------
https://chatgpt.com/codex/tasks/task_e_686f6e8c52f8832f8a1ab3cbb2fd74c6