### PR TITLE
add opencode binary workflow

### DIFF
--- a/.github/workflows/dev-util-opencode-bin-update.yaml
+++ b/.github/workflows/dev-util-opencode-bin-update.yaml
@@ -1,0 +1,141 @@
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github Binary Release /workspace/arrans_overlay/current.config 2025-08-06 00:02:14.770763933 +0000 UTC m=+0.013301672
+
+name: dev-util/opencode-bin update
+
+permissions:
+  contents: write
+
+on:
+  schedule:
+    - cron: '5 14 * * *'
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/dev-util-opencode-bin-update.yaml'
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  ecn: dev-util
+  epn: opencode-bin
+  description: "AI coding agent, built for the terminal."
+  homepage: "https://opencode.ai"
+  github_owner: sst
+  github_repo: opencode
+  keywords: ~amd64 ~arm64
+  workflow_filename: dev-util-opencode-bin-update.yaml
+  opencode_binary_installed_name: 'opencode'
+  opencode_binary_archived_name_amd64: 'opencode'
+  opencode_release_name_amd64: 'opencode-linux-x64.zip'
+  opencode_binary_archived_name_arm64: 'opencode'
+  opencode_release_name_arm64: 'opencode-linux-arm64.zip'
+
+jobs:
+  check-and-create-ebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Install required tools
+        run: |
+            sudo apt-get update
+            sudo apt-get install -y wget jq coreutils
+            url="$(curl -s --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/arran4/g2/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("_linux_amd64.deb"))')"
+            echo "$url"
+            wget "${url}" -O /tmp/g2.deb
+            sudo dpkg -i /tmp/g2.deb
+            rm /tmp/g2.deb
+
+      - name: Process each release
+        id: process_releases
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p $ebuild_dir
+          declare -A releaseTypes=()
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          for tag in $tags; do
+            version="${tag}"
+            originalVersion="${version}"
+            if ! echo "${version}" | egrep '^([0-9]+)\.([0-9]+)(\.([0-9]+))?(-r[0-9]+)?((_)(alpha|beta|rc|p)[0-9]*)*$'; then
+                echo "tag / $version doesn't match regexp";
+                continue;
+            fi
+            releaseType="$(echo "${version}" | sed -n 's/^[^_]\+_\(alpha\|beta\|rc\|p[0-9]*\).*$/\1/p')"
+            if [[ ! -v releaseTypes[${releaseType:=release}] ]]; then
+                if [[ -v releaseTypes[release] ]]; then
+                  echo "Already have a newer main release: ${releaseTypes[release]}"
+                  continue
+                fi
+                releaseTypes[${releaseType:=release}]="${version}"
+            else
+                echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
+                continue
+            fi
+            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
+            if [ ! -f "$ebuild_file" ]; then
+
+              {
+                echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
+                echo 'EAPI=8'
+                echo "DESCRIPTION=\"${{ env.description }}\""
+                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'LICENSE="MIT"'
+                echo 'SLOT="0"'
+                echo 'KEYWORDS="${{ env.keywords }}"'
+                echo 'IUSE=""'
+                echo 'REQUIRED_USE=""'
+                echo 'DEPEND=""'
+                echo 'RDEPEND="sys-libs/glibc "'
+                echo 'S="${WORKDIR}"'
+                echo ''
+                echo ''
+                echo 'SRC_URI="'
+                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/opencode-linux-x64.zip -> \${P}-opencode-linux-x64.zip  )  "
+                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/opencode-linux-arm64.zip -> \${P}-opencode-linux-arm64.zip  )  "
+                echo '"'
+                echo ''
+                echo 'src_unpack() {'
+                echo '  if use amd64; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-opencode-linux-x64.zip\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '  if use arm64; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-opencode-linux-arm64.zip\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '}'
+                echo ''
+                echo 'src_install() {'
+                echo '  exeinto /opt/bin'
+                echo '  if use amd64; then'
+                echo '    newexe "${{ env.opencode_binary_archived_name_amd64 }}" "${{ env.opencode_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '  if use arm64; then'
+                echo '    newexe "${{ env.opencode_binary_archived_name_arm64 }}" "${{ env.opencode_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '}'
+                echo ""
+              } > $ebuild_file
+
+              # Manifest generation
+
+              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/opencode-linux-x64.zip" "${{ env.epn }}-${version}-opencode-linux-x64.zip" "${ebuild_dir}/Manifest"
+              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/opencode-linux-arm64.zip" "${{ env.epn }}-${version}-opencode-linux-arm64.zip" "${ebuild_dir}/Manifest"
+              echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
+            fi
+          done
+
+      - name: Commit and push changes
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          git add ./${ebuild_dir}
+          git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}" &&
+          git pull --rebase &&
+          git push || true
+        if: steps.process_releases.outputs.generated_tag

--- a/current.config
+++ b/current.config
@@ -597,3 +597,17 @@ ProgramName fq
 Binary amd64=>fq_${VERSION}_linux_amd64.tar.gz > fq > fq
 Binary arm64=>fq_${VERSION}_linux_arm64.tar.gz > fq > fq
 
+
+Type Github Binary Release
+GithubProjectUrl https://github.com/sst/opencode
+Category dev-util
+EbuildName opencode-bin
+Description AI coding agent, built for the terminal.
+Homepage https://opencode.ai
+License MIT License
+Workaround Semantic Version Without V
+ProgramName opencode
+Dependencies sys-libs/glibc
+Binary amd64=>opencode-linux-x64.zip > opencode > opencode
+Binary arm64=>opencode-linux-arm64.zip > opencode > opencode
+


### PR DESCRIPTION
## Summary
- add opencode to overlay build config
- add CI workflow to generate opencode binary ebuilds

## Testing
- `yamllint -d '{rules: {line-length: {max: 500}}}' .github/workflows/dev-util-opencode-bin-update.yaml && echo YAMLLINT_OK`

------
https://chatgpt.com/codex/tasks/task_e_68929a593264832f9a1b4bacf79c67bd