### PR TITLE
Regenerate workflows with updated builder

### DIFF
--- a/.github/workflows/app-admin-arrans-overlay-workflow-builder-bin-update.yaml
+++ b/.github/workflows/app-admin-arrans-overlay-workflow-builder-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.10 Github Binary Release current.config 2024-08-19 00:13:48.967470266 +1000 AEST m=+0.001938198
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github Binary Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: app-admin/arrans-overlay-workflow-builder-bin update
 
@@ -58,7 +58,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then

--- a/.github/workflows/app-admin-chezmoi-bin-update.yaml
+++ b/.github/workflows/app-admin-chezmoi-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github Binary Release ./test.config 2024-09-16 16:39:43.946039544 +1000 AEST m=+0.001777926
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github Binary Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: app-admin/chezmoi-bin update
 
@@ -68,13 +68,13 @@ jobs:
 
       - name: Install required tools
         run: |
-          sudo apt-get update
-          sudo apt-get install -y wget jq coreutils
-          url="$(curl -s --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/arran4/g2/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("_linux_amd64.deb"))')"
-          echo "$url"
-          wget "${url}" -O /tmp/g2.deb
-          sudo dpkg -i /tmp/g2.deb
-          rm /tmp/g2.deb
+            sudo apt-get update
+            sudo apt-get install -y wget jq coreutils
+            url="$(curl -s --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/arran4/g2/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("_linux_amd64.deb"))')"
+            echo "$url"
+            wget "${url}" -O /tmp/g2.deb
+            sudo dpkg -i /tmp/g2.deb
+            rm /tmp/g2.deb
 
       - name: Process each release
         id: process_releases
@@ -82,7 +82,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then

--- a/.github/workflows/app-admin-ejson-bin-update.yaml
+++ b/.github/workflows/app-admin-ejson-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.17 Github Binary Release current.config 2025-06-17 14:07:34.728975652 +0000 UTC m=+0.004588620
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github Binary Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: app-admin/ejson-bin update
 
@@ -60,7 +60,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then

--- a/.github/workflows/app-admin-g2-bin-update.yaml
+++ b/.github/workflows/app-admin-g2-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.10 Github Binary Release current.config 2024-08-19 00:13:48.967470266 +1000 AEST m=+0.001938198
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github Binary Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: app-admin/g2-bin update
 
@@ -62,7 +62,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then

--- a/.github/workflows/app-misc-anytype-to-linkwarden-bin-update.yaml
+++ b/.github/workflows/app-misc-anytype-to-linkwarden-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github Binary Release ./test.config 2024-09-16 16:36:54.526505379 +1000 AEST m=+0.001946399
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github Binary Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: app-misc/anytype-to-linkwarden-bin update
 
@@ -21,7 +21,7 @@ env:
   ecn: app-misc
   epn: anytype-to-linkwarden-bin
   description: "TODO"
-  homepage: "https://github.com/arran4/anytype-to-linkwarden-bin"
+  homepage: ""
   github_owner: arran4
   github_repo: anytype-to-linkwarden
   keywords: ~amd64 ~arm64
@@ -46,13 +46,13 @@ jobs:
 
       - name: Install required tools
         run: |
-          sudo apt-get update
-          sudo apt-get install -y wget jq coreutils
-          url="$(curl -s --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/arran4/g2/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("_linux_amd64.deb"))')"
-          echo "$url"
-          wget "${url}" -O /tmp/g2.deb
-          sudo dpkg -i /tmp/g2.deb
-          rm /tmp/g2.deb
+            sudo apt-get update
+            sudo apt-get install -y wget jq coreutils
+            url="$(curl -s --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/arran4/g2/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("_linux_amd64.deb"))')"
+            echo "$url"
+            wget "${url}" -O /tmp/g2.deb
+            sudo dpkg -i /tmp/g2.deb
+            rm /tmp/g2.deb
 
       - name: Process each release
         id: process_releases
@@ -60,7 +60,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then

--- a/.github/workflows/app-misc-chatbox-appimage-update.yaml
+++ b/.github/workflows/app-misc-chatbox-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github AppImage Release /home/arran/Documents/Projects/arrans_overlay/current.config 2024-09-03 18:00:24.938898761 +1000 AEST m=+0.001953322
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github AppImage Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: app-misc/chatbox-appimage update
 
@@ -6,9 +6,9 @@ permissions:
   contents: write
 
 on:
-#  schedule:
-#    - cron: '25 12 * * *'
-#  workflow_dispatch:
+  schedule:
+    - cron: '25 12 * * *'
+  workflow_dispatch:
   push:
     paths:
       - '.github/workflows/app-misc-chatbox-appimage-update.yaml'
@@ -59,7 +59,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+            tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then
@@ -98,8 +98,8 @@ jobs:
                 echo "inherit xdg-utils"
                 echo ''
                 echo 'SRC_URI="'
-                echo "  arm64? ( https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/Chatbox.CE-\${PV}-arm64.AppImage -> \${P}-Chatbox-\${PV}-arm64.AppImage )"
-                echo "  amd64? ( https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/Chatbox.CE-\${PV}-x86_64.AppImage -> \${P}-Chatbox-\${PV}-x86_64.AppImage )"
+                echo "  arm64? ( https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/Chatbox.CE-\${PV}-arm64.AppImage -> \${P}-Chatbox.CE-\${PV}-arm64.AppImage )"
+                echo "  amd64? ( https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/Chatbox.CE-\${PV}-x86_64.AppImage -> \${P}-Chatbox.CE-\${PV}-x86_64.AppImage )"
                 echo '"'
                 echo ''
                 echo 'src_unpack() {'
@@ -141,8 +141,8 @@ jobs:
 
               # Manifest generation
 
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/Chatbox.CE-${version}-arm64.AppImage" "${{ env.epn }}-${version}-Chatbox-${version}-arm64.AppImage" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/Chatbox.CE-${version}-x86_64.AppImage" "${{ env.epn }}-${version}-Chatbox-${version}-x86_64.AppImage" "${ebuild_dir}/Manifest"
+              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/Chatbox.CE-${version}-arm64.AppImage" "${{ env.epn }}-${version}-Chatbox.CE-${version}-arm64.AppImage" "${ebuild_dir}/Manifest"
+              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/Chatbox.CE-${version}-x86_64.AppImage" "${{ env.epn }}-${version}-Chatbox.CE-${version}-x86_64.AppImage" "${ebuild_dir}/Manifest"
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
             fi
           done

--- a/.github/workflows/app-misc-dua-cli-bin-update.yaml
+++ b/.github/workflows/app-misc-dua-cli-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.10 Github Binary Release current.config 2024-08-26 15:54:28.506952372 +1000 AEST m=+0.006874842
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github Binary Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: app-misc/dua-cli-bin update
 
@@ -62,7 +62,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then

--- a/.github/workflows/app-misc-flutter-google-datastore-appimage-update.yaml
+++ b/.github/workflows/app-misc-flutter-google-datastore-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github AppImage Release /home/arran/Documents/Projects/arrans_overlay/current.config 2024-09-03 18:00:24.938898761 +1000 AEST m=+0.001953322
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github AppImage Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: app-misc/flutter-google-datastore-appimage update
 
@@ -28,7 +28,7 @@ env:
   workflow_filename: app-misc-flutter-google-datastore-appimage-update.yaml
   flutter_google_datastore_desktop_file: 'flutter_google_datastore.desktop'
   flutter_google_datastore_appimage_installed_name: 'flutter_google_datastore.AppImage'
-  flutter_google_datastore_release_name_amd64: 'flutter_google_datastore-${version}-linux.AppImage'
+  flutter_google_datastore_release_name_amd64: 'flutter_google_datastore-\${PV}-linux.AppImage'
 
 jobs:
   check-and-create-ebuild:
@@ -58,7 +58,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+            tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then
@@ -98,7 +98,7 @@ jobs:
                 echo "inherit xdg-utils"
                 echo ''
                 echo 'SRC_URI="'
-                echo "  amd64? ( https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/flutter_google_datastore-${version}-linux.AppImage -> \${P}-flutter_google_datastore-${version}-linux.AppImage )"
+                echo "  amd64? ( https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/flutter_google_datastore-${originalVersion}-linux.AppImage -> \${P}-flutter_google_datastore-\${PV}-linux.AppImage )"
                 echo '"'
                 echo ''
                 echo 'src_unpack() {'
@@ -137,7 +137,7 @@ jobs:
 
               # Manifest generation
 
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/flutter_google_datastore-${version}-linux.AppImage" "${{ env.epn }}-${version}-flutter_google_datastore-${version}-linux.AppImage" "${ebuild_dir}/Manifest"
+              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/flutter_google_datastore-${originalVersion}-linux.AppImage" "${{ env.epn }}-${version}-flutter_google_datastore-${version}-linux.AppImage" "${ebuild_dir}/Manifest"
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
             fi
           done

--- a/.github/workflows/app-misc-fq-bin-update.yaml
+++ b/.github/workflows/app-misc-fq-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.17 Github Binary Release current.config 2025-07-03 02:39:10.895874961 +0000 UTC m=+0.006476010
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github Binary Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: app-misc/fq-bin update
 
@@ -60,7 +60,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then

--- a/.github/workflows/app-misc-jan-appimage-update.yaml
+++ b/.github/workflows/app-misc-jan-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github AppImage Release /home/arran/Documents/Projects/arrans_overlay/current.config 2024-09-03 18:00:24.938898761 +1000 AEST m=+0.001953322
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github AppImage Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: app-misc/jan-appimage update
 
@@ -6,8 +6,8 @@ permissions:
   contents: write
 
 on:
-#  schedule:
-#    - cron: '13 5 * * *'
+  schedule:
+    - cron: '13 5 * * *'
   workflow_dispatch:
   push:
     paths:
@@ -58,7 +58,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+            tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then

--- a/.github/workflows/app-misc-local-ai-appimage-update.yaml
+++ b/.github/workflows/app-misc-local-ai-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github AppImage Release /home/arran/Documents/Projects/arrans_overlay/current.config 2024-09-03 18:00:24.938898761 +1000 AEST m=+0.001953322
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github AppImage Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: app-misc/local-ai-appimage update
 
@@ -58,7 +58,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+            tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then

--- a/.github/workflows/app-misc-local-ai-bin-update.yaml
+++ b/.github/workflows/app-misc-local-ai-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.10 Github Binary Release current.config 2024-08-19 00:13:48.967470266 +1000 AEST m=+0.001938198
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github Binary Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: app-misc/local-ai-bin update
 
@@ -29,6 +29,8 @@ env:
   local-ai_binary_installed_name: 'local-ai'
   local-ai_release_name_amd64: 'local-ai-Linux-x86_64'
   local-ai_release_name_arm64: 'local-ai-Linux-arm64'
+  stablediffusion_binary_installed_name: 'stablediffusion'
+  stablediffusion_release_name_amd64: 'stablediffusion'
 
 jobs:
   check-and-create-ebuild:
@@ -58,7 +60,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then
@@ -101,8 +103,11 @@ jobs:
                 echo ''
                 echo 'SRC_URI="'
                 echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/local-ai-Linux-x86_64 -> \${P}-local-ai-Linux-x86_64  )  "
+                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/stablediffusion -> \${P}-stablediffusion  )  "
                 echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/local-ai-Linux-arm64 -> \${P}-local-ai-Linux-arm64  )  "
                 echo '"'
+                echo ''
+                echo 'src_unpack() { : }'
                 echo ''
                 echo 'src_install() {'
                 echo '  exeinto /opt/bin'
@@ -112,6 +117,9 @@ jobs:
                 echo '  if use arm64; then'
                 echo '    newexe "${DISTDIR}/${P}-${{ env.local-ai_release_name_arm64 }}" "${{ env.local-ai_binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
+                echo '  if use amd64; then'
+                echo '    newexe "${DISTDIR}/${P}-${{ env.stablediffusion_release_name_amd64 }}" "${{ env.stablediffusion_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
                 echo '}'
                 echo ""
               } > $ebuild_file
@@ -119,6 +127,7 @@ jobs:
               # Manifest generation
 
               g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/local-ai-Linux-x86_64" "${{ env.epn }}-${version}-local-ai-Linux-x86_64" "${ebuild_dir}/Manifest"
+              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/stablediffusion" "${{ env.epn }}-${version}-stablediffusion" "${ebuild_dir}/Manifest"
               g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/local-ai-Linux-arm64" "${{ env.epn }}-${version}-local-ai-Linux-arm64" "${ebuild_dir}/Manifest"
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
             fi

--- a/.github/workflows/app-misc-maid-appimage-update.yaml
+++ b/.github/workflows/app-misc-maid-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github AppImage Release /home/arran/Documents/Projects/arrans_overlay/current.config 2024-09-03 18:00:24.938898761 +1000 AEST m=+0.001953322
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github AppImage Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: app-misc/maid-appimage update
 
@@ -58,7 +58,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+            tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag}"
             originalVersion="${version}"

--- a/.github/workflows/app-misc-mvcommon-bin-update.yaml
+++ b/.github/workflows/app-misc-mvcommon-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.17 Github Binary Release ./current.config 2024-12-09 14:01:37.273443943 +1100 AEDT m=+0.002594606
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github Binary Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: app-misc/mvcommon-bin update
 
@@ -60,7 +60,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then

--- a/.github/workflows/app-misc-picocrypt-bin-update.yaml
+++ b/.github/workflows/app-misc-picocrypt-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.10 Github Binary Release current.config 2024-08-19 11:46:34.662559864 +1000 AEST m=+0.002931571
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github Binary Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: app-misc/picocrypt-bin update
 
@@ -57,7 +57,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag}"
             originalVersion="${version}"
@@ -97,6 +97,8 @@ jobs:
                 echo 'SRC_URI="'
                 echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/Picocrypt -> \${P}-Picocrypt  )  "
                 echo '"'
+                echo ''
+                echo 'src_unpack() { : }'
                 echo ''
                 echo 'src_install() {'
                 echo '  exeinto /opt/bin'

--- a/.github/workflows/app-misc-rntocase-bin-update.yaml
+++ b/.github/workflows/app-misc-rntocase-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.17 Github Binary Release ./current.config 2024-12-10 23:59:15.353972112 +1100 AEDT m=+0.002266001
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github Binary Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: app-misc/rntocase-bin update
 
@@ -126,7 +126,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then

--- a/.github/workflows/app-misc-stability-matrix-appimage-update.yaml
+++ b/.github/workflows/app-misc-stability-matrix-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github AppImage Release /home/arran/Documents/Projects/arrans_overlay/current.config 2024-09-03 18:00:24.938898761 +1000 AEST m=+0.001953322
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github AppImage Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: app-misc/stability-matrix-appimage update
 
@@ -59,7 +59,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+            tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then
@@ -104,6 +104,9 @@ jobs:
                 echo 'src_unpack() {'
                 echo '  if use amd64; then'
                 echo "    unpack \"\${DISTDIR}/\${P}-StabilityMatrix-linux-x64.zip\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '  if use amd64; then'
+                echo "    mv \"${{ env.StabilityMatrix_appimage_archived_name_amd64 }}\" \"${{ env.StabilityMatrix_appimage_installed_name }}\"  || die \"Can't move archived file\""
                 echo '  fi'
                 echo '  chmod a+x "${{ env.StabilityMatrix_appimage_installed_name }}"  || die "Can'\''t chmod archive file"'
                 echo '  "./${{ env.StabilityMatrix_appimage_installed_name }}" --appimage-extract "${{ env.StabilityMatrix_desktop_file }}" || die "Failed to extract .desktop from appimage"'

--- a/.github/workflows/app-misc-superfile-bin-update.yaml
+++ b/.github/workflows/app-misc-superfile-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.10 Github Binary Release current.config 2024-08-19 00:13:48.967470266 +1000 AEST m=+0.001938198
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github Binary Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: app-misc/superfile-bin update
 
@@ -60,7 +60,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then

--- a/.github/workflows/app-text-anytype-ts-appimage-update.yaml
+++ b/.github/workflows/app-text-anytype-ts-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github AppImage Release /home/arran/Documents/Projects/arrans_overlay/current.config 2024-09-04 16:50:31.674939388 +1000 AEST m=+0.002314554
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github AppImage Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: app-text/anytype-ts-appimage update
 
@@ -58,7 +58,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+            tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then

--- a/.github/workflows/app-text-mostcomm-bin-update.yaml
+++ b/.github/workflows/app-text-mostcomm-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.10 Github Binary Release current.config 2024-08-19 00:13:48.967470266 +1000 AEST m=+0.001938198
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github Binary Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: app-text/mostcomm-bin update
 
@@ -62,7 +62,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then

--- a/.github/workflows/dev-go-goreleaser-bin-update.yaml
+++ b/.github/workflows/dev-go-goreleaser-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.10 Github Binary Release current.config 2024-08-19 00:13:48.967470266 +1000 AEST m=+0.001938198
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github Binary Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: dev-go/goreleaser-bin update
 
@@ -66,7 +66,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then

--- a/.github/workflows/dev-util-editorconfig-guesser-bin-update.yaml
+++ b/.github/workflows/dev-util-editorconfig-guesser-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github Binary Release ./test.config 2024-09-16 16:39:43.946039544 +1000 AEST m=+0.001777926
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github Binary Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: dev-util/editorconfig-guesser-bin update
 
@@ -26,13 +26,13 @@ env:
   github_repo: editorconfig-guesser
   keywords: ~amd64 ~arm ~arm64
   workflow_filename: dev-util-editorconfig-guesser-bin-update.yaml
-  ecguess_binary_installed_name: 'ecguess'
-  ecguess_binary_archived_name_amd64: 'ecguess'
-  ecguess_release_name_amd64: 'cards_\${PV}_linux_amd64.tar.gz'
-  ecguess_binary_archived_name_arm: 'ecguess'
-  ecguess_release_name_arm: 'cards_\${PV}_linux_armv7.tar.gz'
-  ecguess_binary_archived_name_arm64: 'ecguess'
-  ecguess_release_name_arm64: 'cards_\${PV}_linux_arm64.tar.gz'
+  binary_installed_name: 'ecguess'
+  binary_archived_name_amd64: 'ecguess'
+  release_name_amd64: 'cards_\${PV}_linux_amd64.tar.gz'
+  binary_archived_name_arm: 'ecguess'
+  release_name_arm: 'cards_\${PV}_linux_armv7.tar.gz'
+  binary_archived_name_arm64: 'ecguess'
+  release_name_arm64: 'cards_\${PV}_linux_arm64.tar.gz'
 
 jobs:
   check-and-create-ebuild:
@@ -48,13 +48,13 @@ jobs:
 
       - name: Install required tools
         run: |
-          sudo apt-get update
-          sudo apt-get install -y wget jq coreutils
-          url="$(curl -s --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/arran4/g2/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("_linux_amd64.deb"))')"
-          echo "$url"
-          wget "${url}" -O /tmp/g2.deb
-          sudo dpkg -i /tmp/g2.deb
-          rm /tmp/g2.deb
+            sudo apt-get update
+            sudo apt-get install -y wget jq coreutils
+            url="$(curl -s --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/arran4/g2/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("_linux_amd64.deb"))')"
+            echo "$url"
+            wget "${url}" -O /tmp/g2.deb
+            sudo dpkg -i /tmp/g2.deb
+            rm /tmp/g2.deb
 
       - name: Process each release
         id: process_releases
@@ -62,7 +62,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then
@@ -96,7 +96,8 @@ jobs:
                 echo 'LICENSE="MIT"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
-                echo 'IUSE=" ecguess doc"'
+                echo 'IUSE=" doc"'
+                echo 'REQUIRED_USE=""'
                 echo 'DEPEND=""'
                 echo 'RDEPEND=""'
                 echo 'S="${WORKDIR}"'
@@ -104,7 +105,7 @@ jobs:
                 echo ''
                 echo 'SRC_URI="'
                 echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/cards_\${PV}_linux_amd64.tar.gz -> \${P}-cards_\${PV}_linux_amd64.tar.gz  )  "
-                echo "  arm? ( ecguess? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/cards_\${PV}_linux_armv7.tar.gz -> \${P}-cards_\${PV}_linux_armv7.tar.gz  )  )  "
+                echo "  arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/cards_\${PV}_linux_armv7.tar.gz -> \${P}-cards_\${PV}_linux_armv7.tar.gz  )  "
                 echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/cards_\${PV}_linux_arm64.tar.gz -> \${P}-cards_\${PV}_linux_arm64.tar.gz  )  "
                 echo '"'
                 echo ''
@@ -112,7 +113,7 @@ jobs:
                 echo '  if use amd64; then'
                 echo "    unpack \"\${DISTDIR}/\${P}-cards_\${PV}_linux_amd64.tar.gz\" || die \"Can't unpack archive file\""
                 echo '  fi'
-                echo '  if use arm && use ecguess; then'
+                echo '  if use arm; then'
                 echo "    unpack \"\${DISTDIR}/\${P}-cards_\${PV}_linux_armv7.tar.gz\" || die \"Can't unpack archive file\""
                 echo '  fi'
                 echo '  if use arm64; then'
@@ -123,13 +124,13 @@ jobs:
                 echo 'src_install() {'
                 echo '  exeinto /opt/bin'
                 echo '  if use amd64; then'
-                echo '    newexe "${{ env.ecguess_binary_archived_name_amd64 }}" "${{ env.ecguess_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '    newexe "${{ env.binary_archived_name_amd64 }}" "${{ env.binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
-                echo '  if use arm && use ecguess; then'
-                echo '    newexe "${{ env.ecguess_binary_archived_name_arm }}" "${{ env.ecguess_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  if use arm; then'
+                echo '    newexe "${{ env.binary_archived_name_arm }}" "${{ env.binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
                 echo '  if use arm64; then'
-                echo '    newexe "${{ env.ecguess_binary_archived_name_arm64 }}" "${{ env.ecguess_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '    newexe "${{ env.binary_archived_name_arm64 }}" "${{ env.binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
                 echo '  if use doc; then'
                 echo '    if use amd64; then'

--- a/.github/workflows/dev-util-im-hex-appimage-update.yaml
+++ b/.github/workflows/dev-util-im-hex-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github AppImage Release /home/arran/Documents/Projects/arrans_overlay/current.config 2024-09-03 18:00:24.938898761 +1000 AEST m=+0.001953322
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github AppImage Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: dev-util/im-hex-appimage update
 
@@ -58,7 +58,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+            tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then
@@ -107,7 +107,7 @@ jobs:
                 echo '  chmod a+x "${{ env.ImHex_appimage_installed_name }}"  || die "Can'\''t chmod archive file"'
                 echo '  "./${{ env.ImHex_appimage_installed_name }}" --appimage-extract "${{ env.ImHex_desktop_file }}" || die "Failed to extract .desktop from appimage"'
                 echo '  "./${{ env.ImHex_appimage_installed_name }}" --appimage-extract "usr/share/pixmaps" || die "Failed to extract pixmaps icons from app image"'
-                echo '  "./${{ env.ImHex_appimage_installed_name }}" --appimage-extract "*.svg" || die "Failed to extract root icons from app image"'
+                echo '  "./${{ env.ImHex_appimage_installed_name }}" --appimage-extract "*.png" || die "Failed to extract root icons from app image"'
                 echo '}'
                 echo ''
                 echo 'src_prepare() {'
@@ -121,9 +121,9 @@ jobs:
                 echo '  insinto /usr/share/applications'
                 echo '  doins "squashfs-root/${{ env.ImHex_desktop_file }}" || die "Failed to install desktop file"'
                 echo '  insinto /usr/share/pixmaps'
-                echo '  doins squashfs-root/usr/share/pixmaps/*.svg || die "Failed to install icons"'
+                echo '  doins squashfs-root/usr/share/pixmaps/*.png || die "Failed to install icons"'
                 echo '  insinto /usr/share/pixmaps'
-                echo '  doins squashfs-root/*.svg || die "Failed to install icons"'
+                echo '  doins squashfs-root/*.png || die "Failed to install icons"'
                 echo '}'
                 echo ""
                 echo "pkg_postinst() {"

--- a/.github/workflows/dev-vcs-git-credential-oauth-bin-update.yaml
+++ b/.github/workflows/dev-vcs-git-credential-oauth-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github Binary Release /workspace/arrans_overlay/current.config 2025-06-09 08:38:50.134215667 +0000 UTC m=+0.009052077
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github Binary Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: dev-vcs/git-credential-oauth-bin update
 
@@ -62,7 +62,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then

--- a/.github/workflows/dev-vcs-git-tag-inc-bin-update.yaml
+++ b/.github/workflows/dev-vcs-git-tag-inc-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.10 Github Binary Release current.config 2024-08-19 00:13:48.967470266 +1000 AEST m=+0.001938198
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github Binary Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: dev-vcs/git-tag-inc-bin update
 
@@ -62,7 +62,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then

--- a/.github/workflows/net-im-beeper-appimage-update.yaml
+++ b/.github/workflows/net-im-beeper-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.17 Github AppImage Release /tmp/beeper.config 2025-08-24 05:41:36.630232021 +0000 UTC m=+0.014898259
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github AppImage Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: net-im/beeper-appimage update
 
@@ -58,7 +58,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+            tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then

--- a/.github/workflows/net-im-caprine-appimage-update.yaml
+++ b/.github/workflows/net-im-caprine-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github AppImage Release /home/arran/Documents/Projects/arrans_overlay/current.config 2024-09-03 18:00:24.938898761 +1000 AEST m=+0.001953322
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github AppImage Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: net-im/caprine-appimage update
 
@@ -58,7 +58,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+            tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then

--- a/.github/workflows/net-im-lemmy-notify-appimage-update.yaml
+++ b/.github/workflows/net-im-lemmy-notify-appimage-update.yaml
@@ -1,34 +1,34 @@
 # Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github AppImage Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
-name: app-misc/ente-auth-appimage update
+name: net-im/lemmy-notify-appimage update
 
 permissions:
   contents: write
 
 on:
   schedule:
-    - cron: '8 7 * * *'
+    - cron: '48 21 * * *'
   workflow_dispatch:
   push:
     paths:
-      - '.github/workflows/app-misc-ente-auth-appimage-update.yaml'
+      - '.github/workflows/net-im-lemmy-notify-appimage-update.yaml'
 
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
 env:
-  ecn: app-misc
-  epn: ente-auth-appimage
-  description: "Ente's 2FA solution"
-  homepage: "https://ente.io/blog/auth/"
-  github_owner: ente-io
-  github_repo: ente
+  ecn: net-im
+  epn: lemmy-notify-appimage
+  description: "Lemmy Notification app - for desktop atm"
+  homepage: ""
+  github_owner: arran4
+  github_repo: lemmy_notify
   keywords: ~amd64
-  workflow_filename: app-misc-ente-auth-appimage-update.yaml
-  ente_auth_desktop_file: 'ente_auth.desktop'
-  ente_auth_appimage_installed_name: 'ente_auth.AppImage'
-  ente_auth_release_name_amd64: 'ente-${tag}-x86_64.AppImage'
+  workflow_filename: net-im-lemmy-notify-appimage-update.yaml
+  lemmy_notify_desktop_file: 'lemmy_notify.desktop'
+  lemmy_notify_appimage_installed_name: 'lemmy_notify.AppImage'
+  lemmy_notify_release_name_amd64: 'lemmy_notify-linux-x86_64.AppImage'
 
 jobs:
   check-and-create-ebuild:
@@ -60,13 +60,12 @@ jobs:
           declare -A releaseTypes=()
             tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
-            version="${tag#auth-v}"
+            version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then
-                echo "$version == $tag so there is no auth-v removed skipping"
+                echo "$version == $tag so there is no v removed skipping"
                 continue
             fi
             originalVersion="${version}"
-            version="$(echo "${version}" | sed 's/^\([0-9]\+\(\.[0-9]\+\)*\)\(-r[0-9]*\)\?\([-_]\(alpha\|beta\|rc\|p\)\(\|\.\?\([0-9]\+\)\)\)$/\1_\5\3\7/')"
             if ! echo "${version}" | egrep '^([0-9]+)\.([0-9]+)(\.([0-9]+))?(-r[0-9]+)?((_)(alpha|beta|rc|p)[0-9]*)*$'; then
                 echo "version: $version doesn't match regexp";
                 continue;
@@ -98,21 +97,21 @@ jobs:
                 echo "inherit xdg-utils"
                 echo ''
                 echo 'SRC_URI="'
-                echo "  amd64? ( https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/ente-${tag}-x86_64.AppImage -> \${P}-ente-${tag}-x86_64.AppImage )"
+                echo "  amd64? ( https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/lemmy_notify-linux-x86_64.AppImage -> \${P}-lemmy_notify-linux-x86_64.AppImage )"
                 echo '"'
                 echo ''
                 echo 'src_unpack() {'
                 echo '  if use amd64; then'
-                echo "    cp \"\${DISTDIR}/\${P}-${{ env.ente_auth_release_name_amd64 }}\" \"${{ env.ente_auth_appimage_installed_name }}\"  || die \"Can't copy downloaded file\""
+                echo "    cp \"\${DISTDIR}/\${P}-${{ env.lemmy_notify_release_name_amd64 }}\" \"${{ env.lemmy_notify_appimage_installed_name }}\"  || die \"Can't copy downloaded file\""
                 echo '  fi'
-                echo '  chmod a+x "${{ env.ente_auth_appimage_installed_name }}"  || die "Can'\''t chmod archive file"'
-                echo '  "./${{ env.ente_auth_appimage_installed_name }}" --appimage-extract "${{ env.ente_auth_desktop_file }}" || die "Failed to extract .desktop from appimage"'
-                echo '  "./${{ env.ente_auth_appimage_installed_name }}" --appimage-extract "usr/share/icons" || die "Failed to extract hicolor icons from app image"'
-                echo '  "./${{ env.ente_auth_appimage_installed_name }}" --appimage-extract "*.png" || die "Failed to extract root icons from app image"'
+                echo '  chmod a+x "${{ env.lemmy_notify_appimage_installed_name }}"  || die "Can'\''t chmod archive file"'
+                echo '  "./${{ env.lemmy_notify_appimage_installed_name }}" --appimage-extract "${{ env.lemmy_notify_desktop_file }}" || die "Failed to extract .desktop from appimage"'
+                echo '  "./${{ env.lemmy_notify_appimage_installed_name }}" --appimage-extract "usr/share/icons" || die "Failed to extract hicolor icons from app image"'
+                echo '  "./${{ env.lemmy_notify_appimage_installed_name }}" --appimage-extract "*.png" || die "Failed to extract root icons from app image"'
                 echo '}'
                 echo ''
                 echo 'src_prepare() {'
-                echo "  sed -i 's:^Exec=.*:Exec=/opt/bin/${{ env.ente_auth_appimage_installed_name }}:' 'squashfs-root/${{ env.ente_auth_desktop_file }}'"
+                echo "  sed -i 's:^Exec=.*:Exec=/opt/bin/${{ env.lemmy_notify_appimage_installed_name }}:' 'squashfs-root/${{ env.lemmy_notify_desktop_file }}'"
                 echo "  find squashfs-root -type f \( -name index.theme -or -name icon-theme.cache \) -exec rm {} \; "
                 echo "  find squashfs-root -type d -exec rmdir -p --ignore-fail-on-non-empty {} \; "
                 echo '  eapply_user'
@@ -120,9 +119,9 @@ jobs:
                 echo ''
                 echo 'src_install() {'
                 echo '  exeinto /opt/bin'
-                echo '  doexe "${{ env.ente_auth_appimage_installed_name }}" || die "Failed to install AppImage"'
+                echo '  doexe "${{ env.lemmy_notify_appimage_installed_name }}" || die "Failed to install AppImage"'
                 echo '  insinto /usr/share/applications'
-                echo '  doins "squashfs-root/${{ env.ente_auth_desktop_file }}" || die "Failed to install desktop file"'
+                echo '  doins "squashfs-root/${{ env.lemmy_notify_desktop_file }}" || die "Failed to install desktop file"'
                 echo '  insinto /usr/share/icons'
                 echo '  doins -r squashfs-root/usr/share/icons/hicolor || die "Failed to install icons"'
                 echo '  insinto /usr/share/pixmaps'
@@ -137,7 +136,7 @@ jobs:
 
               # Manifest generation
 
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/ente-${tag}-x86_64.AppImage" "${{ env.epn }}-${version}-ente-${tag}-x86_64.AppImage" "${ebuild_dir}/Manifest"
+              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/lemmy_notify-linux-x86_64.AppImage" "${{ env.epn }}-${version}-lemmy_notify-linux-x86_64.AppImage" "${ebuild_dir}/Manifest"
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
             fi
           done

--- a/.github/workflows/net-misc-localsend-appimage-update.yaml
+++ b/.github/workflows/net-misc-localsend-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github AppImage Release /home/arran/Documents/Projects/arrans_overlay/current.config 2024-09-03 18:00:24.938898761 +1000 AEST m=+0.001953322
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github AppImage Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: net-misc/localsend-appimage update
 
@@ -58,7 +58,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+            tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then

--- a/.github/workflows/net-misc-pimtrace-bin-update.yaml
+++ b/.github/workflows/net-misc-pimtrace-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.10 Github Binary Release current.config 2024-08-19 00:13:48.967470266 +1000 AEST m=+0.001938198
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github Binary Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: net-misc/pimtrace-bin update
 
@@ -60,7 +60,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then

--- a/.github/workflows/net-misc-podcast-cdr-manager-bin-update.yaml
+++ b/.github/workflows/net-misc-podcast-cdr-manager-bin-update.yaml
@@ -1,38 +1,38 @@
 # Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github Binary Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
-name: net-im/slackdump-bin update
+name: net-misc/podcast-cdr-manager-bin update
 
 permissions:
   contents: write
 
 on:
   schedule:
-    - cron: '4 16 * * *'
+    - cron: '24 7 * * *'
   workflow_dispatch:
   push:
     paths:
-      - '.github/workflows/net-im-slackdump-bin-update.yaml'
+      - '.github/workflows/net-misc-podcast-cdr-manager-bin-update.yaml'
 
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
 env:
-  ecn: net-im
-  epn: slackdump-bin
-  description: "Save or export your private and public Slack messages, threads, files, and users locally without admin privileges."
+  ecn: net-misc
+  epn: podcast-cdr-manager-bin
+  description: "CLI tool to help manage podcast subscriptions for burning to CDROMs / CDR / CDRW"
   homepage: ""
-  github_owner: rusq
-  github_repo: slackdump
-  keywords: ~amd64 ~arm64 ~x86
-  workflow_filename: net-im-slackdump-bin-update.yaml
-  binary_installed_name: 'slackdump'
-  binary_archived_name_amd64: 'slackdump'
-  release_name_amd64: 'slackdump_Linux_x86_64.tar.gz'
-  binary_archived_name_arm64: 'slackdump'
-  release_name_arm64: 'slackdump_Linux_arm64.tar.gz'
-  binary_archived_name_x86: 'slackdump'
-  release_name_x86: 'slackdump_Linux_i386.tar.gz'
+  github_owner: arran4
+  github_repo: podcast-cdr-manager
+  keywords: ~amd64 ~arm ~arm64
+  workflow_filename: net-misc-podcast-cdr-manager-bin-update.yaml
+  podcastcdrmanager_binary_installed_name: 'podcastcdrmanager'
+  podcastcdrmanager_binary_archived_name_amd64: 'podcastcdrmanager'
+  podcastcdrmanager_release_name_amd64: 'podcastcdrmanager_Linux_x86_64.tar.gz'
+  podcastcdrmanager_binary_archived_name_arm: 'podcastcdrmanager'
+  podcastcdrmanager_release_name_arm: 'podcastcdrmanager_Linux_armv6.tar.gz'
+  podcastcdrmanager_binary_archived_name_arm64: 'podcastcdrmanager'
+  podcastcdrmanager_release_name_arm64: 'podcastcdrmanager_Linux_arm64.tar.gz'
 
 jobs:
   check-and-create-ebuild:
@@ -70,7 +70,6 @@ jobs:
                 continue
             fi
             originalVersion="${version}"
-            version="$(echo "${version}" | sed 's/^\([0-9]\+\(\.[0-9]\+\)*\)\(-r[0-9]*\)\?\([-_]\(alpha\|beta\|rc\|p\)[0-9]*\)$/\1_\5\3/')"
             if ! echo "${version}" | egrep '^([0-9]+)\.([0-9]+)(\.([0-9]+))?(-r[0-9]+)?((_)(alpha|beta|rc|p)[0-9]*)*$'; then
                 echo "tag / $version doesn't match regexp";
                 continue;
@@ -97,7 +96,7 @@ jobs:
                 echo 'LICENSE="MIT"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
-                echo 'IUSE=""'
+                echo 'IUSE=" doc"'
                 echo 'REQUIRED_USE=""'
                 echo 'DEPEND=""'
                 echo 'RDEPEND=""'
@@ -105,33 +104,36 @@ jobs:
                 echo ''
                 echo ''
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/slackdump_Linux_x86_64.tar.gz -> \${P}-slackdump_Linux_x86_64.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/slackdump_Linux_arm64.tar.gz -> \${P}-slackdump_Linux_arm64.tar.gz  )  "
-                echo "  x86? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/slackdump_Linux_i386.tar.gz -> \${P}-slackdump_Linux_i386.tar.gz  )  "
+                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/podcastcdrmanager_Linux_x86_64.tar.gz -> \${P}-podcastcdrmanager_Linux_x86_64.tar.gz  )  "
+                echo "  arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/podcastcdrmanager_Linux_armv6.tar.gz -> \${P}-podcastcdrmanager_Linux_armv6.tar.gz  )  "
+                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/podcastcdrmanager_Linux_arm64.tar.gz -> \${P}-podcastcdrmanager_Linux_arm64.tar.gz  )  "
                 echo '"'
                 echo ''
                 echo 'src_unpack() {'
                 echo '  if use amd64; then'
-                echo "    unpack \"\${DISTDIR}/\${P}-slackdump_Linux_x86_64.tar.gz\" || die \"Can't unpack archive file\""
+                echo "    unpack \"\${DISTDIR}/\${P}-podcastcdrmanager_Linux_x86_64.tar.gz\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '  if use arm; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-podcastcdrmanager_Linux_armv6.tar.gz\" || die \"Can't unpack archive file\""
                 echo '  fi'
                 echo '  if use arm64; then'
-                echo "    unpack \"\${DISTDIR}/\${P}-slackdump_Linux_arm64.tar.gz\" || die \"Can't unpack archive file\""
-                echo '  fi'
-                echo '  if use x86; then'
-                echo "    unpack \"\${DISTDIR}/\${P}-slackdump_Linux_i386.tar.gz\" || die \"Can't unpack archive file\""
+                echo "    unpack \"\${DISTDIR}/\${P}-podcastcdrmanager_Linux_arm64.tar.gz\" || die \"Can't unpack archive file\""
                 echo '  fi'
                 echo '}'
                 echo ''
                 echo 'src_install() {'
                 echo '  exeinto /opt/bin'
                 echo '  if use amd64; then'
-                echo '    newexe "${{ env.binary_archived_name_amd64 }}" "${{ env.binary_installed_name }}" || die "Failed to install Binary"'
+                echo '    newexe "${{ env.podcastcdrmanager_binary_archived_name_amd64 }}" "${{ env.podcastcdrmanager_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '  if use arm; then'
+                echo '    newexe "${{ env.podcastcdrmanager_binary_archived_name_arm }}" "${{ env.podcastcdrmanager_binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
                 echo '  if use arm64; then'
-                echo '    newexe "${{ env.binary_archived_name_arm64 }}" "${{ env.binary_installed_name }}" || die "Failed to install Binary"'
+                echo '    newexe "${{ env.podcastcdrmanager_binary_archived_name_arm64 }}" "${{ env.podcastcdrmanager_binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
-                echo '  if use x86; then'
-                echo '    newexe "${{ env.binary_archived_name_x86 }}" "${{ env.binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  if use doc; then'
+                echo '    newdoc "readme.md" "readme.md" || die "Failed to install document readme.md"'
                 echo '  fi'
                 echo '}'
                 echo ""
@@ -139,9 +141,9 @@ jobs:
 
               # Manifest generation
 
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/slackdump_Linux_x86_64.tar.gz" "${{ env.epn }}-${version}-slackdump_Linux_x86_64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/slackdump_Linux_arm64.tar.gz" "${{ env.epn }}-${version}-slackdump_Linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/slackdump_Linux_i386.tar.gz" "${{ env.epn }}-${version}-slackdump_Linux_i386.tar.gz" "${ebuild_dir}/Manifest"
+              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/podcastcdrmanager_Linux_x86_64.tar.gz" "${{ env.epn }}-${version}-podcastcdrmanager_Linux_x86_64.tar.gz" "${ebuild_dir}/Manifest"
+              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/podcastcdrmanager_Linux_armv6.tar.gz" "${{ env.epn }}-${version}-podcastcdrmanager_Linux_armv6.tar.gz" "${ebuild_dir}/Manifest"
+              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/podcastcdrmanager_Linux_arm64.tar.gz" "${{ env.epn }}-${version}-podcastcdrmanager_Linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
             fi
           done

--- a/.github/workflows/net-misc-rustdesk-appimage-update.yaml
+++ b/.github/workflows/net-misc-rustdesk-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github AppImage Release /home/arran/Documents/Projects/arrans_overlay/current.config 2024-09-03 18:00:24.938898761 +1000 AEST m=+0.001953322
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github AppImage Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: net-misc/rustdesk-appimage update
 
@@ -59,7 +59,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+            tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag}"
             originalVersion="${version}"

--- a/.github/workflows/net-misc-termscp-bin-update.yaml
+++ b/.github/workflows/net-misc-termscp-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.17 Github Binary Release termscp.config 2025-06-11 08:30:59.814984482 +0000 UTC m=+0.004710046
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github Binary Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: net-misc/termscp-bin update
 
@@ -28,9 +28,9 @@ env:
   workflow_filename: net-misc-termscp-bin-update.yaml
   termscp_binary_installed_name: 'termscp'
   termscp_binary_archived_name_amd64: 'termscp'
-  termscp_release_name_amd64: 'termscp-v\${PV}-x86_64-unknown-linux-gnu.tar.gz'
+  termscp_release_name_amd64: 'termscp-v\\${PV}-x86_64-unknown-linux-gnu.tar.gz'
   termscp_binary_archived_name_arm64: 'termscp'
-  termscp_release_name_arm64: 'termscp-\${PV}-aarch64-unknown-linux-gnu.tar.gz'
+  termscp_release_name_arm64: 'termscp-\\${PV}-aarch64-unknown-linux-gnu.tar.gz'
 
 jobs:
   check-and-create-ebuild:
@@ -60,7 +60,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then
@@ -102,16 +102,16 @@ jobs:
                 echo ''
                 echo ''
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/termscp-v\${PV}-x86_64-unknown-linux-gnu.tar.gz -> \${P}-termscp-v\${PV}-x86_64-unknown-linux-gnu.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/termscp-\${PV}-aarch64-unknown-linux-gnu.tar.gz -> \${P}-termscp-\${PV}-aarch64-unknown-linux-gnu.tar.gz  )  "
+                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/termscp-v\\${PV}-x86_64-unknown-linux-gnu.tar.gz -> \${P}-termscp-v\\${PV}-x86_64-unknown-linux-gnu.tar.gz  )  "
+                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/termscp-\\${PV}-aarch64-unknown-linux-gnu.tar.gz -> \${P}-termscp-\\${PV}-aarch64-unknown-linux-gnu.tar.gz  )  "
                 echo '"'
                 echo ''
                 echo 'src_unpack() {'
                 echo '  if use amd64; then'
-                echo "    unpack \"\${DISTDIR}/\${P}-termscp-v\${PV}-x86_64-unknown-linux-gnu.tar.gz\" || die \"Can't unpack archive file\""
+                echo "    unpack \"\${DISTDIR}/\${P}-termscp-v\\${PV}-x86_64-unknown-linux-gnu.tar.gz\" || die \"Can't unpack archive file\""
                 echo '  fi'
                 echo '  if use arm64; then'
-                echo "    unpack \"\${DISTDIR}/\${P}-termscp-\${PV}-aarch64-unknown-linux-gnu.tar.gz\" || die \"Can't unpack archive file\""
+                echo "    unpack \"\${DISTDIR}/\${P}-termscp-\\${PV}-aarch64-unknown-linux-gnu.tar.gz\" || die \"Can't unpack archive file\""
                 echo '  fi'
                 echo '}'
                 echo ''
@@ -129,8 +129,8 @@ jobs:
 
               # Manifest generation
 
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/termscp-v${version}-x86_64-unknown-linux-gnu.tar.gz" "${{ env.epn }}-${version}-termscp-v${version}-x86_64-unknown-linux-gnu.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/termscp-${version}-aarch64-unknown-linux-gnu.tar.gz" "${{ env.epn }}-${version}-termscp-${version}-aarch64-unknown-linux-gnu.tar.gz" "${ebuild_dir}/Manifest"
+              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/termscp-v\${version}-x86_64-unknown-linux-gnu.tar.gz" "${{ env.epn }}-${version}-termscp-v\${version}-x86_64-unknown-linux-gnu.tar.gz" "${ebuild_dir}/Manifest"
+              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/termscp-\${version}-aarch64-unknown-linux-gnu.tar.gz" "${{ env.epn }}-${version}-termscp-\${version}-aarch64-unknown-linux-gnu.tar.gz" "${ebuild_dir}/Manifest"
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
             fi
           done

--- a/.github/workflows/www-apps-hugo-bin-update.yaml
+++ b/.github/workflows/www-apps-hugo-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github Binary Release ./test.config 2024-09-16 16:39:43.946039544 +1000 AEST m=+0.001777926
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github Binary Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: www-apps/hugo-bin update
 
@@ -53,13 +53,13 @@ jobs:
 
       - name: Install required tools
         run: |
-          sudo apt-get update
-          sudo apt-get install -y wget jq coreutils
-          url="$(curl -s --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/arran4/g2/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("_linux_amd64.deb"))')"
-          echo "$url"
-          wget "${url}" -O /tmp/g2.deb
-          sudo dpkg -i /tmp/g2.deb
-          rm /tmp/g2.deb
+            sudo apt-get update
+            sudo apt-get install -y wget jq coreutils
+            url="$(curl -s --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/arran4/g2/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("_linux_amd64.deb"))')"
+            echo "$url"
+            wget "${url}" -O /tmp/g2.deb
+            sudo dpkg -i /tmp/g2.deb
+            rm /tmp/g2.deb
 
       - name: Process each release
         id: process_releases
@@ -67,7 +67,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then

--- a/.github/workflows/www-apps-pagefind-bin-update.yaml
+++ b/.github/workflows/www-apps-pagefind-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.10 Github Binary Release current.config 2024-08-19 00:13:48.967470266 +1000 AEST m=+0.001938198
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.18 Github Binary Release current.config 2025-08-24 12:02:36.738002164 +0000 UTC m=+0.012028373
 
 name: www-apps/pagefind-bin update
 
@@ -22,7 +22,7 @@ env:
   epn: pagefind-bin
   description: "Static low-bandwidth search at scale"
   homepage: "https://pagefind.app"
-  github_owner: Pagefind
+  github_owner: CloudCannon
   github_repo: pagefind
   keywords: ~amd64 ~arm64
   workflow_filename: www-apps-pagefind-bin-update.yaml
@@ -53,7 +53,7 @@ jobs:
         run: |
             sudo apt-get update
             sudo apt-get install -y wget jq coreutils
-            url="$(curl -s -L --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/arran4/g2/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("_linux_amd64.deb"))')"
+            url="$(curl -s --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/arran4/g2/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("_linux_amd64.deb"))')"
             echo "$url"
             wget "${url}" -O /tmp/g2.deb
             sudo dpkg -i /tmp/g2.deb
@@ -65,7 +65,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s -L --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           for tag in $tags; do
             version="${tag#v}"
             if [ "${version}" = "${tag}" ]; then


### PR DESCRIPTION
## Summary
- regenerate GitHub Actions workflows using arrans_overlay_workflow_builder 0.1.18
- add workflows for lemmy-notify and podcast-cdr-manager
- update release tag parsing to avoid jq errors when tag_name is missing

## Testing
- `yamllint .github/workflows/*.yaml` *(fails: line-length, missing document start, trailing spaces)*

------
https://chatgpt.com/codex/tasks/task_e_68aaff0697a0832f90d9b6b1de7eaa9b