### PR TITLE
Ensure git available in Gentoo test workflow

### DIFF
--- a/.github/workflows/run-ebuild-tests.yml
+++ b/.github/workflows/run-ebuild-tests.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Run tests
         run: |
           emerge-webrsync >> sync.txt
+          if ! command -v git >/dev/null 2>&1; then
+            emerge --quiet --oneshot dev-vcs/git
+          fi
           git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
           CHANGED_EBUILDS=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }} HEAD | grep '\.ebuild$' || true)
           if [ -z "$CHANGED_EBUILDS" ]; then


### PR DESCRIPTION
## Summary
- install git inside the Gentoo stage3 test container when it is missing so the workflow can fetch the base branch

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68fda5754200832fa715f90e4b20753d