### PR TITLE
Add shineyshot binary workflow

### DIFF
--- a/.github/workflows/app-misc-shineyshot-bin-update.yaml
+++ b/.github/workflows/app-misc-shineyshot-bin-update.yaml
@@ -1,0 +1,180 @@
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github Binary Release ../current.config 2025-10-26 07:20:26.902299387 +0000 UTC m=+0.024494318
+
+name: app-misc/shineyshot-bin update
+
+permissions:
+  contents: write
+
+on:
+  schedule:
+    - cron: '22 18 * * *'
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/app-misc-shineyshot-bin-update.yaml'
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  ecn: app-misc
+  epn: shineyshot-bin
+  description: "A simple screenshotting tool with several user modes"
+  homepage: "https://github.com/arran4/shineyshot"
+  github_owner: arran4
+  github_repo: shineyshot
+  keywords: ~amd64 ~arm ~arm64 ~x86
+  workflow_filename: app-misc-shineyshot-bin-update.yaml
+  shineyshot_binary_installed_name: 'shineyshot'
+  shineyshot_binary_archived_name_amd64: 'shineyshot'
+  shineyshot_release_name_amd64: 'shineyshot_\${PV}_Linux_x86_64.tar.gz'
+  shineyshot_binary_archived_name_arm: 'shineyshot'
+  shineyshot_release_name_arm: 'shineyshot_\${PV}_Linux_armv7.tar.gz'
+  shineyshot_binary_archived_name_arm64: 'shineyshot'
+  shineyshot_release_name_arm64: 'shineyshot_\${PV}_Linux_arm64.tar.gz'
+  shineyshot_binary_archived_name_x86: 'shineyshot'
+  shineyshot_release_name_x86: 'shineyshot_\${PV}_Linux_i386.tar.gz'
+
+jobs:
+  check-and-create-ebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Install required tools
+        run: |
+            sudo apt-get update
+            sudo apt-get install -y wget jq coreutils
+            url="$(curl -s --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/arran4/g2/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("_linux_amd64.deb"))')"
+            echo "$url"
+            wget "${url}" -O /tmp/g2.deb
+            sudo dpkg -i /tmp/g2.deb
+            rm /tmp/g2.deb
+
+      - name: Process each release
+        id: process_releases
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p $ebuild_dir
+          declare -A releaseTypes=()
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          for tag in $tags; do
+            version="${tag#v}"
+            if [ "${version}" = "${tag}" ]; then
+                echo "$version == $tag so there is no v removed skipping"
+                continue
+            fi
+            originalVersion="${version}"
+            if ! echo "${version}" | egrep '^([0-9]+)\.([0-9]+)(\.([0-9]+))?(-r[0-9]+)?((_)(alpha|beta|rc|p)[0-9]*)*$'; then
+                echo "tag / $version doesn't match regexp";
+                continue;
+            fi
+            releaseType="$(echo "${version}" | sed -n 's/^[^_]\+_\(alpha\|beta\|rc\|p[0-9]*\).*$/\1/p')"
+            if [[ ! -v releaseTypes[${releaseType:=release}] ]]; then
+                if [[ -v releaseTypes[release] ]]; then
+                  echo "Already have a newer main release: ${releaseTypes[release]}"
+                  continue
+                fi
+                releaseTypes[${releaseType:=release}]="${version}"
+            else
+                echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
+                continue
+            fi
+            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
+            if [ ! -f "$ebuild_file" ]; then
+
+              {
+                echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
+                echo 'EAPI=8'
+                echo "DESCRIPTION=\"${{ env.description }}\""
+                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'LICENSE="MIT"'
+                echo 'SLOT="0"'
+                echo 'KEYWORDS="${{ env.keywords }}"'
+                echo 'IUSE=" doc"'
+                echo 'REQUIRED_USE=""'
+                echo 'DEPEND=""'
+                echo 'RDEPEND=""'
+                echo 'S="${WORKDIR}"'
+                echo ''
+                echo ''
+                echo 'SRC_URI="'
+                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/shineyshot_\${PV}_Linux_x86_64.tar.gz -> \${P}-shineyshot_\${PV}_Linux_x86_64.tar.gz  )  "
+                echo "  arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/shineyshot_\${PV}_Linux_armv7.tar.gz -> \${P}-shineyshot_\${PV}_Linux_armv7.tar.gz  )  "
+                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/shineyshot_\${PV}_Linux_arm64.tar.gz -> \${P}-shineyshot_\${PV}_Linux_arm64.tar.gz  )  "
+                echo "  x86? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/shineyshot_\${PV}_Linux_i386.tar.gz -> \${P}-shineyshot_\${PV}_Linux_i386.tar.gz  )  "
+                echo '"'
+                echo ''
+                echo 'src_unpack() {'
+                echo '  if use amd64; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-shineyshot_\${PV}_Linux_x86_64.tar.gz\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '  if use arm; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-shineyshot_\${PV}_Linux_armv7.tar.gz\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '  if use arm64; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-shineyshot_\${PV}_Linux_arm64.tar.gz\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '  if use x86; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-shineyshot_\${PV}_Linux_i386.tar.gz\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '}'
+                echo ''
+                echo 'src_install() {'
+                echo '  exeinto /opt/bin'
+                echo '  if use amd64; then'
+                echo '    newexe "${{ env.shineyshot_binary_archived_name_amd64 }}" "${{ env.shineyshot_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '  if use arm; then'
+                echo '    newexe "${{ env.shineyshot_binary_archived_name_arm }}" "${{ env.shineyshot_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '  if use arm64; then'
+                echo '    newexe "${{ env.shineyshot_binary_archived_name_arm64 }}" "${{ env.shineyshot_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '  if use x86; then'
+                echo '    newexe "${{ env.shineyshot_binary_archived_name_x86 }}" "${{ env.shineyshot_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '  if use doc; then'
+                echo '    if use amd64; then'
+                echo '      newdoc "README.md" "README.md" || die "Failed to install document README.md"'
+                echo '    fi'
+                echo '    if use arm; then'
+                echo '      newdoc "README.md" "README.md" || die "Failed to install document README.md"'
+                echo '      newdoc "README.md" "README.md" || die "Failed to install document README.md"'
+                echo '    fi'
+                echo '    if use arm64; then'
+                echo '      newdoc "README.md" "README.md" || die "Failed to install document README.md"'
+                echo '    fi'
+                echo '    if use x86; then'
+                echo '      newdoc "README.md" "README.md" || die "Failed to install document README.md"'
+                echo '    fi'
+                echo '  fi'
+                echo '}'
+                echo ""
+              } > $ebuild_file
+
+              # Manifest generation
+
+              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/shineyshot_${version}_Linux_x86_64.tar.gz" "${{ env.epn }}-${version}-shineyshot_${version}_Linux_x86_64.tar.gz" "${ebuild_dir}/Manifest"
+              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/shineyshot_${version}_Linux_armv7.tar.gz" "${{ env.epn }}-${version}-shineyshot_${version}_Linux_armv7.tar.gz" "${ebuild_dir}/Manifest"
+              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/shineyshot_${version}_Linux_arm64.tar.gz" "${{ env.epn }}-${version}-shineyshot_${version}_Linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
+              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/shineyshot_${version}_Linux_i386.tar.gz" "${{ env.epn }}-${version}-shineyshot_${version}_Linux_i386.tar.gz" "${ebuild_dir}/Manifest"
+              echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
+            fi
+          done
+
+      - name: Commit and push changes
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          git add ./${ebuild_dir}
+          git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}" &&
+          git pull --rebase &&
+          git push || true
+        if: steps.process_releases.outputs.generated_tag

--- a/current.config
+++ b/current.config
@@ -642,3 +642,22 @@ License unknown
 ProgramName beeper
 Binary ~amd64=>Beeper-${VERSION}.AppImage > beeper.AppImage
 
+
+Type Github Binary Release
+GithubProjectUrl https://github.com/arran4/shineyshot
+Category app-misc
+EbuildName shineyshot-bin
+Description A simple screenshotting tool with several user modes
+Homepage https://github.com/arran4/shineyshot
+License GNU Affero General Public License v3.0
+ProgramName shineyshot
+Document amd64=>shineyshot_${VERSION}_Linux_x86_64.tar.gz > README.md > README.md
+Document arm=>shineyshot_${VERSION}_Linux_armv6.tar.gz > README.md > README.md
+Document arm=>shineyshot_${VERSION}_Linux_armv7.tar.gz > README.md > README.md
+Document arm64=>shineyshot_${VERSION}_Linux_arm64.tar.gz > README.md > README.md
+Document x86=>shineyshot_${VERSION}_Linux_i386.tar.gz > README.md > README.md
+Binary amd64=>shineyshot_${VERSION}_Linux_x86_64.tar.gz > shineyshot > shineyshot
+Binary arm=>shineyshot_${VERSION}_Linux_armv7.tar.gz > shineyshot > shineyshot
+Binary arm64=>shineyshot_${VERSION}_Linux_arm64.tar.gz > shineyshot > shineyshot
+Binary x86=>shineyshot_${VERSION}_Linux_i386.tar.gz > shineyshot > shineyshot
+


### PR DESCRIPTION
## Summary
- add the shineyshot binary release definition to the workflow builder configuration
- generate the corresponding app-misc/shineyshot-bin update workflow

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68fdcaa903a0832fb4041097f0a70e71