### PR TITLE
Remove StabilityMatrix entry referencing Hugging Face

### DIFF
--- a/current.config
+++ b/current.config
@@ -108,19 +108,6 @@ Dependencies sys-libs/glibc sys-libs/zlib
 Binary amd64=>imhex-${VERSION}-x86_64.AppImage > ImHex.AppImage
 
 Type Github AppImage Release
-GithubProjectUrl https://github.com/LykosAI/StabilityMatrix
-Category app-misc
-EbuildName stability-matrix-appimage.ebuild
-Description Multi-Platform Package Manager for Stable Diffusion
-Homepage https://lykos.ai
-License GNU Affero General Public License v3.0
-ProgramName StabilityMatrix
-DesktopFile zone.lykos.stabilitymatrix.desktop
-Icons root
-Dependencies sys-libs/zlib sys-libs/glibc
-Binary amd64=>StabilityMatrix-linux-x64.zip > StabilityMatrix.AppImage > StabilityMatrix.AppImage
-
-Type Github AppImage Release
 GithubProjectUrl https://github.com/louisgv/local.ai
 Category app-misc
 EbuildName local-ai-appimage.ebuild


### PR DESCRIPTION
## Summary
- remove the StabilityMatrix AppImage configuration block from `current.config`
- this drops the remaining reference to the Hugging Face distributed application from the workflow builder config

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6902ad31f884832f92503221db4634b9