### PR TITLE
Fix comic-mono live ebuild source directory

### DIFF
--- a/media-fonts/comic-mono-font/comic-mono-font-9999.ebuild
+++ b/media-fonts/comic-mono-font/comic-mono-font-9999.ebuild
@@ -7,11 +7,13 @@ inherit font
 
 DESCRIPTION=" A legible monospace font... the very typeface you’ve been trained to recognize since childhood."
 HOMEPAGE="https://github.com/dtinth/comic-mono-font/"
+COMMIT="6a133be3235177801e2aaf80619afcd40071c9c0"
+
 SRC_URI="
-	https://github.com/dtinth/comic-mono-font/archive/6a133be3235177801e2aaf80619afcd40071c9c0.zip -> ${P}.zip
+	https://github.com/dtinth/comic-mono-font/archive/${COMMIT}.zip -> ${P}.zip
 "
 
-S="${WORKDIR}/comic-mono-font-master"
+S="${WORKDIR}/${PN}-${COMMIT}"
 
 LICENSE="MIT License"
 SLOT="0"


### PR DESCRIPTION
## Summary
- define the tracked commit hash for comic-mono and use it to construct the source directory name so unpack succeeds

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6902edf84dd4832f91f5fd02a7851685