### PR TITLE
Drop shared-mime-info dependency from antigravity-bin

### DIFF
--- a/dev-util/antigravity-bin/antigravity-bin-1.11.2.6251250307170304.ebuild
+++ b/dev-util/antigravity-bin/antigravity-bin-1.11.2.6251250307170304.ebuild
@@ -16,7 +16,6 @@ RESTRICT="bindist mirror strip"
 RDEPEND="
   app-accessibility/at-spi2-core
   app-crypt/libsecret
-  app-misc/shared-mime-info
   dev-libs/glib
   dev-libs/nss
   media-libs/alsa-lib


### PR DESCRIPTION
## Summary
- remove the shared-mime-info dependency from antigravity-bin
- drop the locally added shared-mime-info ebuild and manifest since it is no longer needed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d17df0044832f825fa16773f8eb0e)