### PR TITLE
Fix piper-voice-hal file paths

### DIFF
--- a/media-sound/piper-voice-hal/piper-voice-hal-0_p20250413.ebuild
+++ b/media-sound/piper-voice-hal/piper-voice-hal-0_p20250413.ebuild
@@ -23,12 +23,12 @@ S="${WORKDIR}"
 RDEPEND="media-sound/piper"
 
 src_install() {
-	local voicedir="/usr/share/piper/voices/hal-9000"
-	
-	insinto "${voicedir}"
-	newins ${PN}-${PV}.onnx hal.onnx || die
-	newins ${PN}-${PV}.onnx.json hal.onnx.json || die
-	newins ${PN}-${PV}.wav model_sample.wav || die
-	
-	dodoc ${PN}-${PV}.README.md
+local voicedir="/usr/share/piper/voices/hal-9000"
+
+insinto "${voicedir}"
+newins "${DISTDIR}/${PN}-${PV}.onnx" hal.onnx || die
+newins "${DISTDIR}/${PN}-${PV}.onnx.json" hal.onnx.json || die
+newins "${DISTDIR}/${PN}-${PV}.wav" model_sample.wav || die
+
+dodoc "${DISTDIR}/${PN}-${PV}.README.md"
 }


### PR DESCRIPTION
## Summary
- install voice artifacts from the distfiles directory
- ensure documentation is taken from the downloaded README

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d0fe42648832fba0f11ee63ae8b71)