### PR TITLE
Rename HAL-9000 ONNX files to match voice directory

### DIFF
--- a/media-sound/piper-voice-hal/piper-voice-hal-0_p20250413.ebuild
+++ b/media-sound/piper-voice-hal/piper-voice-hal-0_p20250413.ebuild
@@ -26,8 +26,8 @@ src_install() {
 local voicedir="/usr/share/piper/voices/hal-9000"
 
 insinto "${voicedir}"
-newins "${DISTDIR}/${PN}-${PV}.onnx" hal.onnx || die
-newins "${DISTDIR}/${PN}-${PV}.onnx.json" hal.onnx.json || die
+newins "${DISTDIR}/${PN}-${PV}.onnx" hal-9000.onnx || die
+newins "${DISTDIR}/${PN}-${PV}.onnx.json" hal-9000.onnx.json || die
 newins "${DISTDIR}/${PN}-${PV}.wav" model_sample.wav || die
 
 dodoc "${DISTDIR}/${PN}-${PV}.README.md"


### PR DESCRIPTION
## Summary
- install the HAL-9000 voice ONNX artifacts using filenames that match the hal-9000 directory

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d10f4ab34832f9c6776aebe6ef067)