### PR TITLE
Fix jules_client installation to include shared libraries

### DIFF
--- a/.github/workflows/app-misc-flutter-jules-bin-update.yaml
+++ b/.github/workflows/app-misc-flutter-jules-bin-update.yaml
@@ -132,6 +132,8 @@ jobs:
                 echo ''
                 echo 'S="${WORKDIR}"'
                 echo ''
+                echo 'QA_PREBUILT="opt/flutter_jules/*"'
+                echo ''
                 echo 'src_unpack() {'
                 echo '  if use amd64; then'
                 echo "    unpack \"\${DISTDIR}/\${P}-flutter_jules-linux.tar.gz\" || die \"Can't unpack archive file\""
@@ -139,9 +141,12 @@ jobs:
                 echo '}'
                 echo ''
                 echo 'src_install() {'
-                echo '  exeinto /opt/bin'
                 echo '  if use amd64; then'
-                echo '    newexe "${{ env.jules_client_binary_archived_name_amd64 }}" "${{ env.jules_client_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '    local dir="/opt/flutter_jules"'
+                echo '    insinto "${dir}"'
+                echo '    doins -r flutter_jules/*'
+                echo '    fperms +x "${dir}/flutter_jules"'
+                echo '    dosym "${dir}/flutter_jules" /usr/bin/jules_client'
                 echo '  fi'
                 echo '}'
               } > $ebuild_file

--- a/app-misc/flutter-jules-bin/flutter-jules-bin-0.0.98.ebuild
+++ b/app-misc/flutter-jules-bin/flutter-jules-bin-0.0.98.ebuild
@@ -16,6 +16,8 @@ RDEPEND="media-libs/libglvnd sys-devel/gcc sys-libs/zlib x11-libs/gtk+ x11-libs/
 
 S="${WORKDIR}"
 
+QA_PREBUILT="opt/flutter_jules/*"
+
 src_unpack() {
   if use amd64; then
     unpack "${DISTDIR}/${P}-flutter_jules-linux.tar.gz" || die "Can't unpack archive file"
@@ -23,8 +25,11 @@ src_unpack() {
 }
 
 src_install() {
-  exeinto /opt/bin
   if use amd64; then
-    newexe "flutter_jules/flutter_jules" "jules_client" || die "Failed to install Binary"
+    local dir="/opt/flutter_jules"
+    insinto "${dir}"
+    doins -r flutter_jules/*
+    fperms +x "${dir}/flutter_jules"
+    dosym "${dir}/flutter_jules" /usr/bin/jules_client
   fi
 }

--- a/current.config
+++ b/current.config
@@ -609,17 +609,6 @@ Binary arm64=>shineyshot_${VERSION}_Linux_arm64.tar.gz > shineyshot > shineyshot
 Binary x86=>shineyshot_${VERSION}_Linux_i386.tar.gz > shineyshot > shineyshot
 
 Type Github Binary Release
-GithubProjectUrl https://github.com/arran4/flutter_jules
-Category app-misc
-EbuildName flutter-jules-bin.ebuild
-Description A comprehensive Flutter-based client application for interacting with the Google Jules API.
-Homepage https://github.com/arran4/flutter_jules
-License unknown
-ProgramName jules_client
-Dependencies sys-libs/glibc sys-libs/zlib x11-libs/gtk+ media-libs/libglvnd x11-libs/libX11 sys-devel/gcc
-Binary amd64=>flutter_jules-linux.tar.gz > flutter_jules/flutter_jules > jules_client
-
-Type Github Binary Release
 GithubProjectUrl https://github.com/arran4/mdsplit
 Category app-text
 EbuildName mdsplit-bin.ebuild


### PR DESCRIPTION
Removed `flutter_jules` from `current.config` to allow manual ebuild maintenance.
Updated `app-misc/flutter-jules-bin/flutter-jules-bin-0.0.98.ebuild` to install the full `flutter_jules` directory to `/opt/flutter_jules` and symlink the binary, ensuring shared libraries are found.
Updated `.github/workflows/app-misc-flutter-jules-bin-update.yaml` to generate the correct ebuild installation logic for future updates.
Added `QA_PREBUILT` to suppress QA warnings for pre-stripped binaries.

---
*PR created automatically by Jules for task [6830640994183825749](https://jules.google.com/task/6830640994183825749) started by @arran4*