### PR TITLE
Add kjules v0.0.1 KDE application ebuild

### DIFF
--- a/app-misc/kjules/kjules-0.0.1.ebuild
+++ b/app-misc/kjules/kjules-0.0.1.ebuild
@@ -1,0 +1,28 @@
+EAPI=8
+
+inherit ecm
+
+DESCRIPTION="kjules KDE application"
+HOMEPAGE="https://github.com/arran4/kjules"
+SRC_URI="https://github.com/arran4/kjules/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${P}"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64"
+
+DEPEND="
+    dev-qt/qtbase:6
+    dev-qt/qtdeclarative:6
+    kde-frameworks/kcoreaddons:6
+    kde-frameworks/ki18n:6
+    kde-frameworks/kxmlgui:6
+"
+RDEPEND="${DEPEND}"
+
+src_configure() {
+    local mycmakeargs=(
+        -DBUILD_TESTING=OFF
+    )
+    ecm_src_configure
+}

--- a/app-misc/kjules/metadata.xml
+++ b/app-misc/kjules/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer type="person">
+    <email>gentoo@arran4.com</email>
+    <name>Arran Ubels</name>
+  </maintainer>
+  <upstream>
+    <remote-id type="github">arran4/kjules</remote-id>
+  </upstream>
+</pkgmetadata>

--- a/metadata/md5-dict/app-misc/kjules-0.0.1
+++ b/metadata/md5-dict/app-misc/kjules-0.0.1
@@ -1,0 +1,23 @@
+KEYWORDS=~amd64
+DEPEND=
+    dev-qt/qtbase:6
+    dev-qt/qtdeclarative:6
+    kde-frameworks/kcoreaddons:6
+    kde-frameworks/ki18n:6
+    kde-frameworks/kxmlgui:6
+
+RDEPEND=
+    dev-qt/qtbase:6
+    dev-qt/qtdeclarative:6
+    kde-frameworks/kcoreaddons:6
+    kde-frameworks/ki18n:6
+    kde-frameworks/kxmlgui:6
+
+EAPI=8
+LICENSE=MIT
+INHERITED=ecm
+HOMEPAGE=https://github.com/arran4/kjules
+SRC_URI=https://github.com/arran4/kjules/archive/refs/tags/v0.0.1.tar.gz -> kjules-0.0.1.tar.gz
+SLOT=0
+DESCRIPTION=kjules KDE application
+_md5_=4fa464c8cb042b76133f2cde4465baf6


### PR DESCRIPTION
This PR introduces a new Gentoo package `app-misc/kjules`, adding a CMake-based ebuild for the KDE application `kjules` at version `v0.0.1`. It uses the standard `ecm` eclass for KDE Frameworks/Qt6 projects and includes standard metadata and caching.

---
*PR created automatically by Jules for task [2004287812522451362](https://jules.google.com/task/2004287812522451362) started by @arran4*