### PR TITLE
ci: verify PRs using g2 lint

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -20,3 +20,12 @@ jobs:
         uses: pkgcore/pkgcheck-action@v1
         with:
           args: --keywords=-UnknownManifest --commits ${{ github.event.pull_request.base.ref && format('origin/{0}', github.event.pull_request.base.ref) || 'HEAD~1' }}
+
+  g2-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install g2
+        run: go install github.com/arran4/g2/cmd/g2@latest
+      - name: Run g2 lint
+        run: ~/go/bin/g2 lint


### PR DESCRIPTION
Added a new GitHub Actions job `g2-lint` to `.github/workflows/pr-checks.yml` to verify Pull Requests using the `g2 lint` tool. It installs the tool directly via `go install github.com/arran4/g2/cmd/g2@latest` and runs the linter across the overlay.

---
*PR created automatically by Jules for task [17796400279713675884](https://jules.google.com/task/17796400279713675884) started by @arran4*