### PR TITLE
ci: fix g2 installation in codex-bin workflow

### DIFF
--- a/.github/workflows/dev-util-codex-bin-update.yaml
+++ b/.github/workflows/dev-util-codex-bin-update.yaml
@@ -44,20 +44,13 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Install required tools
         run: |
             sudo apt-get update
             sudo apt-get install -y wget jq coreutils
-            if command -v go &> /dev/null
-            then
-                go install github.com/arran4/g2@latest
-            else
-                url="$(curl -s --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/arran4/g2/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("_linux_amd64.deb"))')"
-                echo "$url"
-                wget "${url}" -O /tmp/g2.deb
-                sudo dpkg -i /tmp/g2.deb
-                rm /tmp/g2.deb
-            fi
 
       - name: Process each release
         id: process_releases


### PR DESCRIPTION
Replaced the manual go install and fallback debian package download for g2 with the official `arran4/g2-action@v1.2` GitHub Action in the `dev-util-codex-bin-update.yaml` workflow. This fixes the CI failure caused by the repository no longer being a main package.

---
*PR created automatically by Jules for task [5502100091543301758](https://jules.google.com/task/5502100091543301758) started by @arran4*