### PR TITLE
Fix YAML indentation in gemini-cli-bin-update.yaml

### DIFF
--- a/.github/workflows/app-admin-google-cloud-sdk-update.yaml
+++ b/.github/workflows/app-admin-google-cloud-sdk-update.yaml
@@ -97,4 +97,4 @@ jobs:
           git config --global user.email "actions@github.com"
           git add app-admin/google-cloud-sdk/
           git commit -m "Update app-admin/google-cloud-sdk to ${{ steps.fetch_version.outputs.latest_version }}"
-          git push\${empty}
+          git push

--- a/.github/workflows/gemini-cli-bin-update.yaml
+++ b/.github/workflows/gemini-cli-bin-update.yaml
@@ -61,13 +61,13 @@ jobs:
           S="\${WORKDIR}"
 
           src_install() {
-		insinto /opt/\${PN}
-		doins -r .
+            insinto /opt/\${PN}
+            doins -r .
 
-		exeinto /opt/\${PN}
-		doexe gemini.js
+            exeinto /opt/\${PN}
+            doexe gemini.js
 
-		dosym ../../opt/\${PN}/gemini.js /usr/bin/gemini
+            dosym ../../opt/\${PN}/gemini.js /usr/bin/gemini
           }
           EBUILD_CONTENT
 


### PR DESCRIPTION
Fixes the YAML syntax error at line 28 in `.github/workflows/gemini-cli-bin-update.yaml` caused by tab indentation in the multi-line string block.

---
*PR created automatically by Jules for task [15677095350301616993](https://jules.google.com/task/15677095350301616993) started by @arran4*