### PR TITLE
fix: resolve yaml indentation error in gemini-cli-bin workflow

### DIFF
--- a/.github/workflows/gemini-cli-bin-update.yaml
+++ b/.github/workflows/gemini-cli-bin-update.yaml
@@ -61,18 +61,18 @@ jobs:
           S="\${WORKDIR}"
 
           src_install() {
-		insinto /opt/\${PN}
-		doins -r .
+            insinto /opt/\${PN}
+            doins -r .
 
-		exeinto /opt/\${PN}
-		doexe gemini.js
+            exeinto /opt/\${PN}
+            doexe gemini.js
 
-		dosym ../../opt/\${PN}/gemini.js /usr/bin/gemini
+            dosym ../../opt/\${PN}/gemini.js /usr/bin/gemini
           }
           EBUILD_CONTENT
 
           sed -i 's/^ *//' "$EBUILD_FILE"
-          sed -i 's/^	*//' "$EBUILD_FILE"
+          sed -i 's/^\t*//' "$EBUILD_FILE"
 
           echo "updated=true" >> $GITHUB_OUTPUT
           echo "version=${LATEST_VERSION}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fixes a YAML syntax error in `.github/workflows/gemini-cli-bin-update.yaml` reported by actionlint:
`could not parse as YAML: found a tab character where an indentation space is expected [syntax-check]`

The error was caused by literal tab characters being used for indentation inside the `run: |` block, and a literal tab used in a `sed` command string. Replaced the indentation tabs with 12 spaces to match the base level of the block, and modified the `sed` command to use `\t` instead of a literal tab character. Verified the fix using `actionlint`.

---
*PR created automatically by Jules for task [3242894748803877073](https://jules.google.com/task/3242894748803877073) started by @arran4*