### PR TITLE
feat: add games-util/steam-nofile ebuild for limits

### DIFF
--- a/games-util/steam-nofile/files/26-steam-nofile.conf
+++ b/games-util/steam-nofile/files/26-steam-nofile.conf
@@ -1,1 +1,1 @@
-*               hard    nofile             524288
+*               -       nofile             524288

--- a/games-util/steam-nofile/files/26-steam-nofile.conf
+++ b/games-util/steam-nofile/files/26-steam-nofile.conf
@@ -1,0 +1,1 @@
+*               hard    nofile             524288

--- a/games-util/steam-nofile/metadata.xml
+++ b/games-util/steam-nofile/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>gentoo@arran4.com</email>
+		<name>Arran Ubels</name>
+	</maintainer>
+</pkgmetadata>

--- a/games-util/steam-nofile/steam-nofile-1.0.ebuild
+++ b/games-util/steam-nofile/steam-nofile-1.0.ebuild
@@ -1,0 +1,16 @@
+EAPI=8
+
+DESCRIPTION="Install 26-steam-nofile.conf for Steam file descriptor limits"
+HOMEPAGE="https://github.com/arran4/arrans-overlay"
+SRC_URI=""
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64"
+
+S="${WORKDIR}"
+
+src_install() {
+	insinto /etc/security/limits.d
+	doins "${FILESDIR}/26-steam-nofile.conf"
+}

--- a/games-util/steam-nofile/steam-nofile-1.0.ebuild
+++ b/games-util/steam-nofile/steam-nofile-1.0.ebuild
@@ -1,6 +1,6 @@
 EAPI=8
 
-DESCRIPTION="Install 26-steam-nofile.conf for Steam file descriptor limits"
+DESCRIPTION="Sets high file descriptor limits for Steam"
 HOMEPAGE="https://github.com/arran4/arrans-overlay"
 SRC_URI=""
 


### PR DESCRIPTION
Added `games-util/steam-nofile` package with an ebuild to install `/etc/security/limits.d/26-steam-nofile.conf` setting a hard limit for file descriptors to 524288, as requested. Included `metadata.xml` and an empty `Manifest` file. Passed tests and validation.

---
*PR created automatically by Jules for task [17279727336377742873](https://jules.google.com/task/17279727336377742873) started by @arran4*