### PR TITLE
Fix kmagmux qtkeychain dependency

### DIFF
--- a/.github/workflows/net-misc-kmagmux-update.yaml
+++ b/.github/workflows/net-misc-kmagmux-update.yaml
@@ -81,7 +81,7 @@ jobs:
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="~amd64"'
                                 echo 'DEPEND="'
-                echo '	dev-libs/qtkeychain:=[qt6]'
+                echo '	dev-libs/qtkeychain:='
                 echo '	dev-qt/qtbase:6[dbus,gui,network,widgets,concurrent]'
                 echo '	kde-frameworks/kcoreaddons:6'
                 echo '	kde-frameworks/ki18n:6'

--- a/net-misc/kmagmux/kmagmux-0.0.6-r1.ebuild
+++ b/net-misc/kmagmux/kmagmux-0.0.6-r1.ebuild
@@ -15,13 +15,15 @@ LICENSE="GPL-3.0-or-later"
 SLOT="0"
 KEYWORDS="~amd64"
 DEPEND="
+	dev-libs/qtkeychain:=
 	dev-qt/qtbase:6[dbus,gui,network,widgets,concurrent]
 	kde-frameworks/kcoreaddons:6
+	kde-frameworks/ki18n:6
 	kde-frameworks/kxmlgui:6
-	dev-libs/qtkeychain:=[qt6]
 "
 RDEPEND="${DEPEND}"
 BDEPEND="
+	dev-qt/qttools:6[linguist]
 	virtual/pkgconfig
 "
 

--- a/net-misc/kmagmux/kmagmux-0.0.8-r1.ebuild
+++ b/net-misc/kmagmux/kmagmux-0.0.8-r1.ebuild
@@ -15,15 +15,13 @@ LICENSE="GPL-3.0-or-later"
 SLOT="0"
 KEYWORDS="~amd64"
 DEPEND="
-	dev-libs/qtkeychain:=[qt6]
 	dev-qt/qtbase:6[dbus,gui,network,widgets,concurrent]
 	kde-frameworks/kcoreaddons:6
-	kde-frameworks/ki18n:6
 	kde-frameworks/kxmlgui:6
+	dev-libs/qtkeychain:=
 "
 RDEPEND="${DEPEND}"
 BDEPEND="
-	dev-qt/qttools:6[linguist]
 	virtual/pkgconfig
 "
 

--- a/net-misc/kmagmux/kmagmux-0.0.8.ebuild
+++ b/net-misc/kmagmux/kmagmux-0.0.8.ebuild
@@ -1,0 +1,30 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+KFMIN=6.0.0
+QTMIN=6.6.2
+inherit ecm
+
+DESCRIPTION="Torrent file and Magnet link handler for routing to programs / services."
+HOMEPAGE="https://github.com/arran4/KMagMux"
+SRC_URI="https://github.com/arran4/KMagMux/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-3.0-or-later"
+SLOT="0"
+KEYWORDS="~amd64"
+DEPEND="
+	dev-libs/qtkeychain:=
+	dev-qt/qtbase:6[dbus,gui,network,widgets,concurrent]
+	kde-frameworks/kcoreaddons:6
+	kde-frameworks/ki18n:6
+	kde-frameworks/kxmlgui:6
+"
+RDEPEND="${DEPEND}"
+BDEPEND="
+	dev-qt/qttools:6[linguist]
+	virtual/pkgconfig
+"
+
+S="${WORKDIR}/KMagMux-${PV}"

--- a/net-misc/kmagmux/kmagmux-9999.ebuild
+++ b/net-misc/kmagmux/kmagmux-9999.ebuild
@@ -19,7 +19,7 @@ DEPEND="
 	kde-frameworks/kcoreaddons:6
 	kde-frameworks/ki18n:6
 	kde-frameworks/kxmlgui:6
-	dev-libs/qtkeychain:=[qt6]
+	dev-libs/qtkeychain:=
 "
 RDEPEND="${DEPEND}"
 BDEPEND="


### PR DESCRIPTION
Fix `kmagmux` dependency resolution errors caused by `dev-libs/qtkeychain` missing the `[qt6]` USE flag.

- Renamed `kmagmux-0.0.6.ebuild` to `kmagmux-0.0.6-r1.ebuild`.
- Renamed `kmagmux-0.0.8.ebuild` to `kmagmux-0.0.8-r1.ebuild`.
- Removed `[qt6]` from `dev-libs/qtkeychain:=` in `kmagmux-0.0.6-r1.ebuild`.
- Removed `[qt6]` from `dev-libs/qtkeychain:=` in `kmagmux-0.0.8-r1.ebuild`.
- Removed `[qt6]` from `dev-libs/qtkeychain:=` in `kmagmux-9999.ebuild`.
- Removed `[qt6]` from `dev-libs/qtkeychain:=` in `.github/workflows/net-misc-kmagmux-update.yaml`.

---
*PR created automatically by Jules for task [12035608849426243288](https://jules.google.com/task/12035608849426243288) started by @arran4*