### PR TITLE
Fix Antigravity binary download URL and version parsing

### DIFF
--- a/.github/workflows/dev-util-antigravity-bin-update.yaml
+++ b/.github/workflows/dev-util-antigravity-bin-update.yaml
@@ -60,7 +60,7 @@ jobs:
           fi
           fi
 
-          curl -sL --compressed -A "Mozilla/5.0" https://antigravity.google/download/linux > /tmp/index.html
+          curl -sL --compressed -A "Mozilla/5.0" https://antigravity.google/download > /tmp/index.html
           main_js=$(grep -o 'main-[^"]*\.js' /tmp/index.html | head -n 1 | tr -d '\r')
           echo "main_js: $main_js"
           if [ -z "$main_js" ]; then
@@ -78,7 +78,7 @@ jobs:
             exit 1
           fi
 
-          version=$(echo "$download_url" | awk -F'/' '{for(i=1;i<=NF;i++) if($i=="stable") print $(i+1)}')
+          version=$(echo "$download_url" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+-[0-9]+' | head -n 1)
           echo "version: $version"
           if [ -z "$version" ]; then
             echo "Could not find version"


### PR DESCRIPTION
The structure of the antigravity download page changed to `https://antigravity.google/download`. This pull request updates the `dev-util-antigravity-bin-update.yaml` GitHub workflow to correctly scrape the new URL. It also updates the version extraction logic to properly parse the new format, utilizing a robust regex to ensure reliability even if the URL structure changes further.

---
*PR created automatically by Jules for task [29647837777974967](https://jules.google.com/task/29647837777974967) started by @arran4*