### PR TITLE
Fix dev-util/antigravity-bin workflow version extraction

### DIFF
--- a/.github/workflows/dev-util-antigravity-bin-update.yaml
+++ b/.github/workflows/dev-util-antigravity-bin-update.yaml
@@ -78,7 +78,7 @@ jobs:
             exit 1
           fi
 
-          version=$(echo "$download_url" | awk -F'/' '{for(i=1;i<=NF;i++) if($i=="stable") print $(i+1)}')
+          version=$(echo "$download_url" | awk -F'/' '{for(i=1;i<=NF;i++) if($i=="antigravity-hub") print $(i+1)}')
           echo "version: $version"
           if [ -z "$version" ]; then
             echo "Could not find version"


### PR DESCRIPTION
Fixes the failing `dev-util-antigravity-bin-update.yaml` GitHub Actions workflow.

The workflow was failing with a `Could not find version` error because the download URL format for Antigravity changed. The version is no longer after a `stable` segment, but rather after an `antigravity-hub` segment. This commit updates the `awk` command in the bash script to properly identify and extract the version string from the new URL format.

---
*PR created automatically by Jules for task [2636347817750094795](https://jules.google.com/task/2636347817750094795) started by @arran4*