### PR TITLE
ci: fix ambiguous emerge packages and make jobs non-fatal in daily tasks

### DIFF
--- a/.github/workflows/scheduled-daily-tasks.yml
+++ b/.github/workflows/scheduled-daily-tasks.yml
@@ -22,7 +22,7 @@ jobs:
           echo 'ACCEPT_LICENSE="*"' > /etc/portage/make.conf
           mkdir -p /var/db/repos/gentoo
           emerge-webrsync
-          emerge --quiet app-portage/portage-utils dev-vcs/git dev-lang/python dev-python/packaging curl jq gh
+          emerge --quiet app-portage/portage-utils dev-vcs/git dev-lang/python dev-python/packaging net-misc/curl app-misc/jq dev-util/github-cli
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -39,6 +39,7 @@ jobs:
 
       - name: Remove duplicate ebuilds
         id: dedupe
+        continue-on-error: true
         run: |
           chmod +x ./scripts/remove_duplicate_ebuilds.py
           OUTPUT=$(./scripts/remove_duplicate_ebuilds.py)
@@ -49,6 +50,7 @@ jobs:
 
       - name: Run egencache update
         id: egencache
+        continue-on-error: true
         run: |
           OUTPUT=$(egencache --repo=arrans-overlay --update 2>&1 || true)
           echo "EGENCACHE_OUTPUT<<INNER_EOF" >> $GITHUB_ENV


### PR DESCRIPTION
Replaced ambiguous package names in emerge command (jq, curl, gh) with fully-qualified Gentoo package names (app-misc/jq, net-misc/curl, dev-util/github-cli).
Added continue-on-error: true to the dedupe and egencache steps so that if one fails, the workflow continues and successfully creates the PR summary.

---
*PR created automatically by Jules for task [309098993415339579](https://jules.google.com/task/309098993415339579) started by @arran4*