### PR TITLE
fix: format PR body diff as markdown block

### DIFF
--- a/.github/workflows/scheduled-daily-tasks.yml
+++ b/.github/workflows/scheduled-daily-tasks.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Generate Readable Diff
         if: steps.check_changes.outputs.has_changes == 'true'
         run: |
-          OUTPUT=$(git diff HEAD --word-diff=plain | head -c 60000 | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/\[-/~~/g' -e 's/-\]/~~/g' -e 's/{+/**/g' -e 's/+}/\*\*/g')
+          OUTPUT=$(git diff HEAD | head -c 60000)
           echo "READABLE_DIFF<<INNER_EOF" >> $GITHUB_ENV
           echo "$OUTPUT" >> $GITHUB_ENV
           echo "INNER_EOF" >> $GITHUB_ENV
@@ -132,7 +132,9 @@ jobs:
             <details>
             <summary>Readable Diff</summary>
 
+            ```diff
             ${{ env.READABLE_DIFF }}
+            ```
             </details>
           branch: "chore/scheduled-daily-tasks"
           delete-branch: true


### PR DESCRIPTION
Resolves issue where the "Readable Diff" in the PR body from the scheduled daily tasks workflow was not correctly readable.

Changes:
- Removed `--word-diff=plain` flag and custom string manipulation meant to imitate markdown formats (which resulted in plain text without correct highlighting).
- Removed the `sed` HTML escaping as it conflicts with rendering within markdown code blocks.
- Wrapped the raw git diff inside standard ` ```diff ` markdown fenced code blocks within the PR body template.

---
*PR created automatically by Jules for task [12083302095424500625](https://jules.google.com/task/12083302095424500625) started by @arran4*