### PR TITLE
Ensure exclusive KF6/Qt6 configurations for kjules, kllamabooks, and kgithub-notify

### DIFF
--- a/.github/workflows/app-misc-kjules-update.yaml
+++ b/.github/workflows/app-misc-kjules-update.yaml
@@ -69,6 +69,8 @@ jobs:
                 echo "# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/app-misc-kjules-update.yaml"
                 echo "EAPI=8"
                 echo ""
+                echo "KFMIN=6.0.0"
+                echo "QTMIN=6.6.2"
                 echo "inherit ecm"
                 echo ""
                 echo "DESCRIPTION=\"$description\""

--- a/app-misc/kjules/kjules-0.0.34-r1.ebuild
+++ b/app-misc/kjules/kjules-0.0.34-r1.ebuild
@@ -1,6 +1,8 @@
 # Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/app-misc-kjules-update.yaml
 EAPI=8
 
+KFMIN=6.0.0
+QTMIN=6.6.2
 inherit ecm
 
 DESCRIPTION="kjules KDE application"

--- a/app-misc/kjules/kjules-0.0.38-r1.ebuild
+++ b/app-misc/kjules/kjules-0.0.38-r1.ebuild
@@ -1,6 +1,8 @@
 # Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/app-misc-kjules-update.yaml
 EAPI=8
 
+KFMIN=6.0.0
+QTMIN=6.6.2
 inherit ecm
 
 DESCRIPTION="kjules KDE application"

--- a/app-misc/kjules/kjules-0.0.40-r1.ebuild
+++ b/app-misc/kjules/kjules-0.0.40-r1.ebuild
@@ -1,6 +1,8 @@
 # Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/app-misc-kjules-update.yaml
 EAPI=8
 
+KFMIN=6.0.0
+QTMIN=6.6.2
 inherit ecm
 
 DESCRIPTION="kjules KDE application"

--- a/app-misc/kjules/kjules-0.0.40.ebuild
+++ b/app-misc/kjules/kjules-0.0.40.ebuild
@@ -1,0 +1,36 @@
+# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/app-misc-kjules-update.yaml
+EAPI=8
+
+KFMIN=6.0.0
+QTMIN=6.6.2
+inherit ecm
+
+DESCRIPTION="kjules KDE application"
+HOMEPAGE="https://github.com/arran4/kjules"
+SRC_URI="https://github.com/arran4/kjules/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${P}"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64"
+
+DEPEND="
+	dev-qt/qtbase:6
+	dev-qt/qtdeclarative:6
+	kde-frameworks/kcoreaddons:6
+	kde-frameworks/ki18n:6
+	kde-frameworks/kxmlgui:6
+"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	ecm_src_prepare
+	sed -i -e 's/KDE_INSTALL_KXMLGUI6DIR/KDE_INSTALL_KXMLGUIDIR/g' CMakeLists.txt || die
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DBUILD_TESTING=OFF
+	)
+	ecm_src_configure
+}

--- a/app-misc/kllamabooks/kllamabooks-0.0.13-r1.ebuild
+++ b/app-misc/kllamabooks/kllamabooks-0.0.13-r1.ebuild
@@ -3,7 +3,9 @@
 
 EAPI=8
 
-inherit cmake xdg
+KFMIN=6.0.0
+QTMIN=6.6.2
+inherit ecm
 
 DESCRIPTION="An AI LLM Desktop Client and Document Editor for KDE/Qt"
 HOMEPAGE="https://github.com/arran4/kllamabooks"
@@ -34,10 +36,9 @@ RDEPEND="${DEPEND}"
 BDEPEND="
 	dev-qt/qttools:6[linguist]
 	virtual/pkgconfig
-	kde-frameworks/extra-cmake-modules:0
 "
 
 src_prepare() {
 	sed -i -e 's/icon.svg/icon.png/g' CMakeLists.txt || die
-	cmake_src_prepare
+	ecm_src_prepare
 }

--- a/app-misc/kllamabooks/kllamabooks-0.0.14-r1.ebuild
+++ b/app-misc/kllamabooks/kllamabooks-0.0.14-r1.ebuild
@@ -3,7 +3,9 @@
 
 EAPI=8
 
-inherit cmake xdg
+KFMIN=6.0.0
+QTMIN=6.6.2
+inherit ecm
 
 DESCRIPTION="An AI LLM Desktop Client and Document Editor for KDE/Qt"
 HOMEPAGE="https://github.com/arran4/kllamabooks"
@@ -34,10 +36,9 @@ RDEPEND="${DEPEND}"
 BDEPEND="
 	dev-qt/qttools:6[linguist]
 	virtual/pkgconfig
-	kde-frameworks/extra-cmake-modules:0
 "
 
 src_prepare() {
 	sed -i -e 's/icon.svg/icon.png/g' CMakeLists.txt || die
-	cmake_src_prepare
+	ecm_src_prepare
 }

--- a/app-misc/kllamabooks/kllamabooks-9999.ebuild
+++ b/app-misc/kllamabooks/kllamabooks-9999.ebuild
@@ -3,7 +3,9 @@
 
 EAPI=8
 
-inherit cmake xdg
+KFMIN=6.0.0
+QTMIN=6.6.2
+inherit ecm
 
 DESCRIPTION="An AI LLM Desktop Client and Document Editor for KDE/Qt"
 HOMEPAGE="https://github.com/arran4/kllamabooks"
@@ -34,10 +36,9 @@ RDEPEND="${DEPEND}"
 BDEPEND="
 	dev-qt/qttools:6[linguist]
 	virtual/pkgconfig
-	kde-frameworks/extra-cmake-modules:0
 "
 
 src_prepare() {
 	sed -i -e 's/icon.svg/icon.png/g' CMakeLists.txt || die
-	cmake_src_prepare
+	ecm_src_prepare
 }

--- a/dev-vcs/kgithub-notify/kgithub-notify-0.1.21-r1.ebuild
+++ b/dev-vcs/kgithub-notify/kgithub-notify-0.1.21-r1.ebuild
@@ -3,7 +3,9 @@
 
 EAPI=8
 
-inherit cmake xdg
+KFMIN=6.0.0
+QTMIN=6.6.2
+inherit ecm
 
 DESCRIPTION="A GitHub notification tool for KDE/Qt"
 HOMEPAGE="https://github.com/arran4/kgithub-notify"
@@ -28,5 +30,4 @@ RDEPEND="${DEPEND}"
 BDEPEND="
 	dev-qt/qttools:6[linguist]
 	virtual/pkgconfig
-	kde-frameworks/extra-cmake-modules:0
 "

--- a/dev-vcs/kgithub-notify/kgithub-notify-0.1.23-r1.ebuild
+++ b/dev-vcs/kgithub-notify/kgithub-notify-0.1.23-r1.ebuild
@@ -3,7 +3,9 @@
 
 EAPI=8
 
-inherit cmake xdg
+KFMIN=6.0.0
+QTMIN=6.6.2
+inherit ecm
 
 DESCRIPTION="A GitHub notification tool for KDE/Qt"
 HOMEPAGE="https://github.com/arran4/kgithub-notify"
@@ -28,5 +30,4 @@ RDEPEND="${DEPEND}"
 BDEPEND="
 	dev-qt/qttools:6[linguist]
 	virtual/pkgconfig
-	kde-frameworks/extra-cmake-modules:0
 "

--- a/metadata/md5-dict/app-misc/kjules-0.0.34-r1
+++ b/metadata/md5-dict/app-misc/kjules-0.0.34-r1
@@ -1,0 +1,23 @@
+LICENSE=MIT
+EAPI=8
+HOMEPAGE=https://github.com/arran4/kjules
+DEPEND=
+	dev-qt/qtbase:6
+	dev-qt/qtdeclarative:6
+	kde-frameworks/kcoreaddons:6
+	kde-frameworks/ki18n:6
+	kde-frameworks/kxmlgui:6
+
+DESCRIPTION=kjules KDE application
+SLOT=0
+SRC_URI=https://github.com/arran4/kjules/archive/refs/tags/v0.0.34-r1.tar.gz -> kjules-0.0.34-r1.tar.gz
+RDEPEND=
+	dev-qt/qtbase:6
+	dev-qt/qtdeclarative:6
+	kde-frameworks/kcoreaddons:6
+	kde-frameworks/ki18n:6
+	kde-frameworks/kxmlgui:6
+
+KEYWORDS=~amd64
+INHERITED=ecm
+_md5_=2251ef3fca2b659db51b011ca1110cf8

--- a/metadata/md5-dict/app-misc/kjules-0.0.38-r1
+++ b/metadata/md5-dict/app-misc/kjules-0.0.38-r1
@@ -1,0 +1,23 @@
+SLOT=0
+DEPEND=
+	dev-qt/qtbase:6
+	dev-qt/qtdeclarative:6
+	kde-frameworks/kcoreaddons:6
+	kde-frameworks/ki18n:6
+	kde-frameworks/kxmlgui:6
+
+HOMEPAGE=https://github.com/arran4/kjules
+RDEPEND=
+	dev-qt/qtbase:6
+	dev-qt/qtdeclarative:6
+	kde-frameworks/kcoreaddons:6
+	kde-frameworks/ki18n:6
+	kde-frameworks/kxmlgui:6
+
+SRC_URI=https://github.com/arran4/kjules/archive/refs/tags/v0.0.38-r1.tar.gz -> kjules-0.0.38-r1.tar.gz
+LICENSE=MIT
+EAPI=8
+KEYWORDS=~amd64
+INHERITED=ecm
+DESCRIPTION=kjules KDE application
+_md5_=2251ef3fca2b659db51b011ca1110cf8

--- a/metadata/md5-dict/app-misc/kjules-0.0.40-r1
+++ b/metadata/md5-dict/app-misc/kjules-0.0.40-r1
@@ -1,0 +1,23 @@
+DESCRIPTION=kjules KDE application
+HOMEPAGE=https://github.com/arran4/kjules
+SLOT=0
+KEYWORDS=~amd64
+DEPEND=
+	dev-qt/qtbase:6
+	dev-qt/qtdeclarative:6
+	kde-frameworks/kcoreaddons:6
+	kde-frameworks/ki18n:6
+	kde-frameworks/kxmlgui:6
+
+INHERITED=ecm
+EAPI=8
+LICENSE=MIT
+SRC_URI=https://github.com/arran4/kjules/archive/refs/tags/v0.0.40-r1.tar.gz -> kjules-0.0.40-r1.tar.gz
+RDEPEND=
+	dev-qt/qtbase:6
+	dev-qt/qtdeclarative:6
+	kde-frameworks/kcoreaddons:6
+	kde-frameworks/ki18n:6
+	kde-frameworks/kxmlgui:6
+
+_md5_=2251ef3fca2b659db51b011ca1110cf8

--- a/metadata/md5-dict/app-misc/kllamabooks-0.0.13-r1
+++ b/metadata/md5-dict/app-misc/kllamabooks-0.0.13-r1
@@ -1,25 +1,6 @@
-LICENSE=MIT
 INHERITED=ecm git-r3
-DESCRIPTION=An AI LLM Desktop Client and Document Editor for KDE/Qt
-SRC_URI=https://github.com/arran4/kllamabooks/archive/refs/tags/v9999.tar.gz -> kllamabooks-9999.tar.gz
-BDEPEND=
-	dev-qt/qttools:6[linguist]
-	virtual/pkgconfig
-
 EAPI=8
-KEYWORDS=~amd64
 SLOT=0
-HOMEPAGE=https://github.com/arran4/kllamabooks
-RDEPEND=
-	dev-qt/qtbase:6[dbus,gui,network,widgets]
-	dev-qt/qtsvg:6
-	kde-frameworks/kconfigwidgets:6
-	kde-frameworks/kcoreaddons:6
-	kde-frameworks/ki18n:6
-	kde-frameworks/kwallet:6
-	kde-frameworks/kxmlgui:6
-	dev-db/sqlcipher
-
 DEPEND=
 	dev-qt/qtbase:6[dbus,gui,network,widgets]
 	dev-qt/qtsvg:6
@@ -30,4 +11,23 @@ DEPEND=
 	kde-frameworks/kxmlgui:6
 	dev-db/sqlcipher
 
+DESCRIPTION=An AI LLM Desktop Client and Document Editor for KDE/Qt
+HOMEPAGE=https://github.com/arran4/kllamabooks
+BDEPEND=
+	dev-qt/qttools:6[linguist]
+	virtual/pkgconfig
+
+SRC_URI=https://github.com/arran4/kllamabooks/archive/refs/tags/v0.0.13-r1.tar.gz -> kllamabooks-0.0.13-r1.tar.gz
+LICENSE=MIT
+RDEPEND=
+	dev-qt/qtbase:6[dbus,gui,network,widgets]
+	dev-qt/qtsvg:6
+	kde-frameworks/kconfigwidgets:6
+	kde-frameworks/kcoreaddons:6
+	kde-frameworks/ki18n:6
+	kde-frameworks/kwallet:6
+	kde-frameworks/kxmlgui:6
+	dev-db/sqlcipher
+
+KEYWORDS=~amd64
 _md5_=2de59cc503ecc948e3531e05fd2702fd

--- a/metadata/md5-dict/app-misc/kllamabooks-0.0.14-r1
+++ b/metadata/md5-dict/app-misc/kllamabooks-0.0.14-r1
@@ -1,15 +1,18 @@
 LICENSE=MIT
-INHERITED=ecm git-r3
-DESCRIPTION=An AI LLM Desktop Client and Document Editor for KDE/Qt
-SRC_URI=https://github.com/arran4/kllamabooks/archive/refs/tags/v9999.tar.gz -> kllamabooks-9999.tar.gz
-BDEPEND=
-	dev-qt/qttools:6[linguist]
-	virtual/pkgconfig
-
-EAPI=8
-KEYWORDS=~amd64
 SLOT=0
 HOMEPAGE=https://github.com/arran4/kllamabooks
+DEPEND=
+	dev-qt/qtbase:6[dbus,gui,network,widgets]
+	dev-qt/qtsvg:6
+	kde-frameworks/kconfigwidgets:6
+	kde-frameworks/kcoreaddons:6
+	kde-frameworks/ki18n:6
+	kde-frameworks/kwallet:6
+	kde-frameworks/kxmlgui:6
+	dev-db/sqlcipher
+
+INHERITED=ecm git-r3
+SRC_URI=https://github.com/arran4/kllamabooks/archive/refs/tags/v0.0.14-r1.tar.gz -> kllamabooks-0.0.14-r1.tar.gz
 RDEPEND=
 	dev-qt/qtbase:6[dbus,gui,network,widgets]
 	dev-qt/qtsvg:6
@@ -20,14 +23,11 @@ RDEPEND=
 	kde-frameworks/kxmlgui:6
 	dev-db/sqlcipher
 
-DEPEND=
-	dev-qt/qtbase:6[dbus,gui,network,widgets]
-	dev-qt/qtsvg:6
-	kde-frameworks/kconfigwidgets:6
-	kde-frameworks/kcoreaddons:6
-	kde-frameworks/ki18n:6
-	kde-frameworks/kwallet:6
-	kde-frameworks/kxmlgui:6
-	dev-db/sqlcipher
+EAPI=8
+DESCRIPTION=An AI LLM Desktop Client and Document Editor for KDE/Qt
+KEYWORDS=~amd64
+BDEPEND=
+	dev-qt/qttools:6[linguist]
+	virtual/pkgconfig
 
 _md5_=2de59cc503ecc948e3531e05fd2702fd

--- a/metadata/md5-dict/dev-vcs/kgithub-notify-0.1.21-r1
+++ b/metadata/md5-dict/dev-vcs/kgithub-notify-0.1.21-r1
@@ -1,0 +1,33 @@
+DESCRIPTION=A GitHub notification tool for KDE/Qt
+DEPEND=
+	dev-qt/qtbase:6[dbus,gui,network,widgets]
+	dev-qt/qtsvg:6
+	kde-frameworks/kconfigwidgets:6
+	kde-frameworks/kcoreaddons:6
+	kde-frameworks/ki18n:6
+	kde-frameworks/knotifications:6
+	kde-frameworks/kwallet:6
+	kde-frameworks/kxmlgui:6
+
+EAPI=8
+SRC_URI=https://github.com/arran4/kgithub-notify/archive/refs/tags/v0.1.21-r1.tar.gz -> kgithub-notify-0.1.21-r1.tar.gz
+LICENSE=BSD
+INHERITED=ecm
+SLOT=0
+BDEPEND=
+	dev-qt/qttools:6[linguist]
+	virtual/pkgconfig
+
+RDEPEND=
+	dev-qt/qtbase:6[dbus,gui,network,widgets]
+	dev-qt/qtsvg:6
+	kde-frameworks/kconfigwidgets:6
+	kde-frameworks/kcoreaddons:6
+	kde-frameworks/ki18n:6
+	kde-frameworks/knotifications:6
+	kde-frameworks/kwallet:6
+	kde-frameworks/kxmlgui:6
+
+KEYWORDS=~amd64
+HOMEPAGE=https://github.com/arran4/kgithub-notify
+_md5_=468e7465502bc99d507a2a523be2e738

--- a/metadata/md5-dict/dev-vcs/kgithub-notify-0.1.23-r1
+++ b/metadata/md5-dict/dev-vcs/kgithub-notify-0.1.23-r1
@@ -1,0 +1,33 @@
+LICENSE=BSD
+DEPEND=
+	dev-qt/qtbase:6[dbus,gui,network,widgets]
+	dev-qt/qtsvg:6
+	kde-frameworks/kconfigwidgets:6
+	kde-frameworks/kcoreaddons:6
+	kde-frameworks/ki18n:6
+	kde-frameworks/knotifications:6
+	kde-frameworks/kwallet:6
+	kde-frameworks/kxmlgui:6
+
+BDEPEND=
+	dev-qt/qttools:6[linguist]
+	virtual/pkgconfig
+
+RDEPEND=
+	dev-qt/qtbase:6[dbus,gui,network,widgets]
+	dev-qt/qtsvg:6
+	kde-frameworks/kconfigwidgets:6
+	kde-frameworks/kcoreaddons:6
+	kde-frameworks/ki18n:6
+	kde-frameworks/knotifications:6
+	kde-frameworks/kwallet:6
+	kde-frameworks/kxmlgui:6
+
+EAPI=8
+SLOT=0
+DESCRIPTION=A GitHub notification tool for KDE/Qt
+INHERITED=ecm
+SRC_URI=https://github.com/arran4/kgithub-notify/archive/refs/tags/v0.1.23-r1.tar.gz -> kgithub-notify-0.1.23-r1.tar.gz
+KEYWORDS=~amd64
+HOMEPAGE=https://github.com/arran4/kgithub-notify
+_md5_=468e7465502bc99d507a2a523be2e738


### PR DESCRIPTION
This PR ensures that `kjules`, `kllamabooks`, and `kgithub-notify` build against KDE Frameworks 6 (KF6) and Qt6 without pulling in legacy KF5 dependencies (such as `kde-frameworks/kxmlgui-5.116.0`). 

To resolve the discrepancy described by the user, the packages' ebuilds were converted to formally utilize the `ecm` eclass (instead of manual `cmake xdg` implementations). Explicit boundaries (`KFMIN=6.0.0` and `QTMIN=6.6.2`) were added to inform the `ecm` eclass configuration to use Qt6 and KF6 components, and `extra-cmake-modules:0` was dropped from `BDEPEND` to avoid manually pulling KF5-inclusive packages.

All non-live packages received a `-r1` revision bump to adequately deploy these tree changes, and the GitHub actions CI generator for `kjules` was adjusted to consistently output the updated format moving forward.

---
*PR created automatically by Jules for task [14626087854969747935](https://jules.google.com/task/14626087854969747935) started by @arran4*