### PR TITLE
Fix antigravity-bin installation failure due to missing icon

### DIFF
--- a/.github/workflows/dev-util-antigravity-bin-update.yaml
+++ b/.github/workflows/dev-util-antigravity-bin-update.yaml
@@ -114,6 +114,14 @@ jobs:
               echo 'SRC_URI="amd64? ( '"${download_url}"' -> ${P}.tar.gz )"'
               echo ''
               echo 'S="${WORKDIR}/Antigravity"'
+              echo ""
+              echo "BDEPEND=\"app-arch/asar\""
+              echo ""
+              echo "src_prepare() {"
+              echo "  default"
+              echo "  asar extract-file resources/app.asar icon.png \"\${WORKDIR}/icon.png\" || die"
+              echo "}"
+
               echo ''
               echo 'src_install() {'
               echo '  insinto /opt/antigravity'
@@ -122,7 +130,7 @@ jobs:
               echo '  fperms 4755 /opt/antigravity/chrome-sandbox'
               echo '  fperms +x /opt/antigravity/chrome_crashpad_handler'
               echo '  dosym ../antigravity/antigravity /opt/bin/antigravity'
-              echo '  newicon "resources/app/resources/linux/code.png" antigravity.png'
+              echo '  newicon "${WORKDIR}/icon.png" antigravity.png'
               echo '  domenu "${FILESDIR}/antigravity-bin.desktop"'
               echo '}'
             } > "$ebuild_file"

--- a/.github/workflows/dev-util-antigravity-bin-update.yaml
+++ b/.github/workflows/dev-util-antigravity-bin-update.yaml
@@ -119,7 +119,7 @@ jobs:
               echo ""
               echo "src_prepare() {"
               echo "  default"
-              echo "  asar extract-file resources/app.asar icon.png \"\${WORKDIR}/icon.png\" || die"
+              echo "  asar extract-file resources/app.asar resources/linux/code.png \"\${WORKDIR}/icon.png\" || die"
               echo "}"
 
               echo ''

--- a/dev-util/antigravity-bin/antigravity-bin-2.0.6_p5413878570549248.ebuild
+++ b/dev-util/antigravity-bin/antigravity-bin-2.0.6_p5413878570549248.ebuild
@@ -20,7 +20,7 @@ BDEPEND="app-arch/asar"
 
 src_prepare() {
 	default
-	asar extract-file resources/app.asar icon.png "${WORKDIR}/icon.png" || die
+	asar extract-file resources/app.asar resources/linux/code.png "${WORKDIR}/icon.png" || die
 }
 
 src_install() {

--- a/dev-util/antigravity-bin/antigravity-bin-2.0.6_p5413878570549248.ebuild
+++ b/dev-util/antigravity-bin/antigravity-bin-2.0.6_p5413878570549248.ebuild
@@ -16,6 +16,13 @@ SRC_URI="amd64? ( https://storage.googleapis.com/antigravity-public/antigravity-
 
 S="${WORKDIR}/Antigravity-x64"
 
+BDEPEND="app-arch/asar"
+
+src_prepare() {
+	default
+	asar extract-file resources/app.asar icon.png "${WORKDIR}/icon.png" || die
+}
+
 src_install() {
   insinto /opt/antigravity
   doins -r *
@@ -23,6 +30,6 @@ src_install() {
   fperms 4755 /opt/antigravity/chrome-sandbox
   fperms +x /opt/antigravity/chrome_crashpad_handler
   dosym ../antigravity/antigravity /opt/bin/antigravity
-  newicon "resources/app/resources/linux/code.png" antigravity.png
+  newicon "${WORKDIR}/icon.png" antigravity.png
   domenu "${FILESDIR}/antigravity-bin.desktop"
 }


### PR DESCRIPTION
Fixes an installation failure in `dev-util/antigravity-bin` where the installation phase attempts to use a missing icon at `resources/app/resources/linux/code.png`.

The icon was packed inside `resources/app.asar`. This adds `app-arch/asar` to BDEPEND, extracts `icon.png` from the asar archive during `src_prepare()`, and uses the extracted file in `src_install()`. The GitHub Actions workflow is also updated to reflect this fix.

---
*PR created automatically by Jules for task [18050902228040765804](https://jules.google.com/task/18050902228040765804) started by @arran4*