### PR TITLE
feat: group scheduled daily tasks output by package

### DIFF
--- a/.github/workflows/scheduled-daily-tasks.yml
+++ b/.github/workflows/scheduled-daily-tasks.yml
@@ -112,8 +112,10 @@ jobs:
           if echo "${DEDUPE_OUTPUT}" | grep -q "Removed duplicated ebuilds:"; then
             SUMMARY="${SUMMARY}**Duplicate Ebuilds Removed:**\n\n"
             while IFS= read -r line; do
-              if [[ "$line" =~ ^[[:space:]]*-[[:space:]]+(.*)/([^/]+)\\.ebuild$ ]]; then
-                SUMMARY="${SUMMARY}- \`${BASH_REMATCH[1]}\` (\`${BASH_REMATCH[2]}\`)\n"
+              if [[ "$line" =~ ^[[:space:]]*-[[:space:]]+([^[:space:]]+)[[:space:]]+(\(.*\))$ ]]; then
+                SUMMARY="${SUMMARY}- \`${BASH_REMATCH[1]}\` ${BASH_REMATCH[2]}\n"
+              elif [[ "$line" =~ ^[[:space:]]*-[[:space:]]+(.*)/([^/]+)\\.ebuild(.*)$ ]]; then
+                SUMMARY="${SUMMARY}- \`${BASH_REMATCH[1]}\` (\`${BASH_REMATCH[2]}\`)${BASH_REMATCH[3]}\n"
               elif [[ "$line" =~ ^[[:space:]]*-[[:space:]]+(.*)$ ]]; then
                 SUMMARY="${SUMMARY}- \`${BASH_REMATCH[1]}\`\n"
               fi

--- a/scripts/remove_duplicate_ebuilds.py
+++ b/scripts/remove_duplicate_ebuilds.py
@@ -183,10 +183,44 @@ def main(repo_root):
     if removed:
         for pkg_dir in {os.path.dirname(p) for p in removed}:
             cleanup(pkg_dir)
-        print("Removed duplicated ebuilds:")
+
+        pkg_summary = defaultdict(lambda: {"removed": set(), "remaining": set()})
+
         for p in removed:
             rel_p = os.path.relpath(p, repo_root)
-            print(f" - {rel_p}")
+            pkg_dir = os.path.dirname(rel_p)
+            file_name = os.path.basename(rel_p)
+            try:
+                ver, rev = split_ebuild_name(file_name)
+                full_ver = ver if rev == "r0" else f"{ver}-{rev}"
+                pkg_summary[pkg_dir]["removed"].add(full_ver)
+            except ValueError:
+                pkg_summary[pkg_dir]["removed"].add(file_name)
+
+        for pkg_dir in pkg_summary:
+            full_pkg_dir = os.path.join(repo_root, pkg_dir)
+            try:
+                entries = os.listdir(full_pkg_dir)
+                for entry in entries:
+                    if entry.endswith(".ebuild"):
+                        try:
+                            ver, rev = split_ebuild_name(entry)
+                            full_ver = ver if rev == "r0" else f"{ver}-{rev}"
+                            pkg_summary[pkg_dir]["remaining"].add(full_ver)
+                        except ValueError:
+                            pkg_summary[pkg_dir]["remaining"].add(entry)
+            except FileNotFoundError:
+                pass
+
+        print("Removed duplicated ebuilds:")
+        for pkg_dir, data in sorted(pkg_summary.items()):
+            removed_str = " ".join([f"-{v}" for v in sorted(data["removed"], key=version_key)])
+            remaining_str = " ".join([f"+{v}" for v in sorted(data["remaining"], key=version_key)])
+
+            if remaining_str:
+                print(f" - {pkg_dir} ({removed_str} {remaining_str})")
+            else:
+                print(f" - {pkg_dir} ({removed_str})")
     else:
         print("No duplicates found")
 


### PR DESCRIPTION
Update the `remove_duplicate_ebuilds.py` script to group output by package instead of listing every duplicate separately. It now prints summary strings like `- category/package (-old1 -old2 +new)`. Update `.github/workflows/scheduled-daily-tasks.yml` to correctly parse and extract this grouped data for the PR summary. Fixes #545.

---
*PR created automatically by Jules for task [8768832553861695282](https://jules.google.com/task/8768832553861695282) started by @arran4*