### PR TITLE
Fix dev-util/antigravity-bin source directory and remove obsolete asar dependency

### DIFF
--- a/.github/workflows/dev-util-antigravity-bin-update.yaml
+++ b/.github/workflows/dev-util-antigravity-bin-update.yaml
@@ -113,14 +113,9 @@ jobs:
               echo ''
               echo 'SRC_URI="amd64? ( '"${download_url}"' -> ${P}.tar.gz )"'
               echo ''
-              echo 'S="${WORKDIR}/Antigravity"'
+              echo 'S="${WORKDIR}/Antigravity-x64"'
               echo ""
-              echo "BDEPEND=\"app-arch/asar\""
               echo ""
-              echo "src_prepare() {"
-              echo "  default"
-              echo "  asar extract-file resources/app.asar resources/linux/code.png \"\${WORKDIR}/icon.png\" || die"
-              echo "}"
 
               echo ''
               echo 'src_install() {'
@@ -130,7 +125,6 @@ jobs:
               echo '  fperms 4755 /opt/antigravity/chrome-sandbox'
               echo '  fperms +x /opt/antigravity/chrome_crashpad_handler'
               echo '  dosym ../antigravity/antigravity /opt/bin/antigravity'
-              echo '  newicon "${WORKDIR}/icon.png" antigravity.png'
               echo '  domenu "${FILESDIR}/antigravity-bin.desktop"'
               echo '}'
             } > "$ebuild_file"

--- a/dev-util/antigravity-bin/antigravity-bin-2.0.10_p5119448496078848.ebuild
+++ b/dev-util/antigravity-bin/antigravity-bin-2.0.10_p5119448496078848.ebuild
@@ -14,7 +14,7 @@ QA_PREBUILT="opt/antigravity/antigravity opt/antigravity/chrome-sandbox opt/anti
 
 SRC_URI="amd64? ( https://storage.googleapis.com/antigravity-public/antigravity-hub/2.0.10-5119448496078848/linux-x64/Antigravity.tar.gz -> ${P}.tar.gz )"
 
-S="${WORKDIR}/Antigravity"
+S="${WORKDIR}/Antigravity-x64"
 
 src_install() {
   insinto /opt/antigravity


### PR DESCRIPTION
Update dev-util/antigravity-bin to correctly extract and install following a major upstream format change.
This fixes an installation issue where the ebuild expected an `Antigravity` directory instead of the actual `Antigravity-x64` directory, and removed obsolete `asar` icon extraction logic.

---
*PR created automatically by Jules for task [8309651260877553888](https://jules.google.com/task/8309651260877553888) started by @arran4*