### PR TITLE
Fix antigravity-bin desktop update QA notice

### DIFF
--- a/.github/workflows/dev-util-antigravity-bin-update.yaml
+++ b/.github/workflows/dev-util-antigravity-bin-update.yaml
@@ -99,7 +99,7 @@ jobs:
             {
               echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
               echo 'EAPI=8'
-              echo 'inherit desktop'
+              echo 'inherit desktop xdg'
               echo "DESCRIPTION=\"${{ env.description }}\""
               echo "HOMEPAGE=\"${{ env.homepage }}\""
               echo 'LICENSE="Antigravity"'

--- a/dev-util/antigravity-bin/antigravity-bin-2.0.10_p5119448496078848.ebuild
+++ b/dev-util/antigravity-bin/antigravity-bin-2.0.10_p5119448496078848.ebuild
@@ -1,6 +1,6 @@
 # Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/dev-util-antigravity-bin-update.yaml
 EAPI=8
-inherit desktop
+inherit desktop xdg
 DESCRIPTION="Google Antigravity AI-driven IDE (binary release)"
 HOMEPAGE="https://antigravity.google/"
 LICENSE="Antigravity"


### PR DESCRIPTION
This commit updates `dev-util/antigravity-bin` and its generation script to inherit the `xdg` eclass. This resolves a Gentoo QA notice complaining that `xdg_desktop_database_update()` was not called for desktop files containing a MimeType.

---
*PR created automatically by Jules for task [6945274754586556285](https://jules.google.com/task/6945274754586556285) started by @arran4*