### PR TITLE
chore: group removed ebuilds by package

### DIFF
--- a/.github/workflows/scheduled-daily-tasks.yml
+++ b/.github/workflows/scheduled-daily-tasks.yml
@@ -112,9 +112,7 @@ jobs:
           if echo "${DEDUPE_OUTPUT}" | grep -q "Removed duplicated ebuilds:"; then
             SUMMARY="${SUMMARY}**Duplicate Ebuilds Removed:**\n\n"
             while IFS= read -r line; do
-              if [[ "$line" =~ ^[[:space:]]*-[[:space:]]+(.*)/([^/]+)\\.ebuild$ ]]; then
-                SUMMARY="${SUMMARY}- \`${BASH_REMATCH[1]}\` (\`${BASH_REMATCH[2]}\`)\n"
-              elif [[ "$line" =~ ^[[:space:]]*-[[:space:]]+(.*)$ ]]; then
+              if [[ "$line" =~ ^[[:space:]]*-[[:space:]]+(.*)$ ]]; then
                 SUMMARY="${SUMMARY}- \`${BASH_REMATCH[1]}\`\n"
               fi
             done <<< "${DEDUPE_OUTPUT}"

--- a/scripts/remove_duplicate_ebuilds.py
+++ b/scripts/remove_duplicate_ebuilds.py
@@ -192,8 +192,8 @@ def main(repo_root):
                 cat = parts[-3]
                 pkg = parts[-2]
                 ebuild_file = parts[-1]
-                if ebuild_file.startswith(pkg):
-                    ver_part = ebuild_file[len(pkg):-7]
+                if ebuild_file.startswith(pkg + '-'):
+                    ver_part = ebuild_file[len(pkg) + 1:-7]
                     grouped[f"{cat}/{pkg}"].append(ver_part)
                 else:
                     grouped[f"{cat}/{pkg}"].append(ebuild_file)
@@ -201,7 +201,8 @@ def main(repo_root):
                 grouped["unknown"].append(rel_p)
 
         for pkg, vers in grouped.items():
-            print(f" - {pkg} ({', '.join(sorted(vers))})")
+            formatted_vers = ', '.join([f"-{v}" if not v.startswith('-') else v for v in sorted(vers)])
+            print(f" - {pkg} ({formatted_vers})")
     else:
         print("No duplicates found")
 

--- a/scripts/remove_duplicate_ebuilds.py
+++ b/scripts/remove_duplicate_ebuilds.py
@@ -184,9 +184,24 @@ def main(repo_root):
         for pkg_dir in {os.path.dirname(p) for p in removed}:
             cleanup(pkg_dir)
         print("Removed duplicated ebuilds:")
+        grouped = defaultdict(list)
         for p in removed:
             rel_p = os.path.relpath(p, repo_root)
-            print(f" - {rel_p}")
+            parts = rel_p.split(os.sep)
+            if len(parts) >= 3:
+                cat = parts[-3]
+                pkg = parts[-2]
+                ebuild_file = parts[-1]
+                if ebuild_file.startswith(pkg):
+                    ver_part = ebuild_file[len(pkg):-7]
+                    grouped[f"{cat}/{pkg}"].append(ver_part)
+                else:
+                    grouped[f"{cat}/{pkg}"].append(ebuild_file)
+            else:
+                grouped["unknown"].append(rel_p)
+
+        for pkg, vers in grouped.items():
+            print(f" - {pkg} ({', '.join(sorted(vers))})")
     else:
         print("No duplicates found")
 


### PR DESCRIPTION
Updated scripts/remove_duplicate_ebuilds.py to group ebuild
removals by package name and output them as a list of versions.
Adjusted the regex in scheduled-daily-tasks.yml to match the
new format.

---
*PR created automatically by Jules for task [17754310146156566084](https://jules.google.com/task/17754310146156566084) started by @arran4*