### PR TITLE
fix: remove dev-python/packaging from scheduled-daily-tasks emerge list to avoid slot conflict

### DIFF
--- a/.github/workflows/scheduled-daily-tasks.yml
+++ b/.github/workflows/scheduled-daily-tasks.yml
@@ -38,7 +38,7 @@ jobs:
           echo 'FEATURES="-ipc-sandbox -network-sandbox -pid-sandbox"' >> /etc/portage/make.conf
           mkdir -p /var/db/repos/gentoo
           emerge-webrsync
-          emerge --quiet app-portage/portage-utils dev-vcs/git dev-lang/python dev-python/packaging net-misc/curl app-misc/jq dev-util/github-cli
+          emerge --quiet app-portage/portage-utils dev-vcs/git dev-lang/python net-misc/curl app-misc/jq dev-util/github-cli
 
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Explicitly requesting `dev-python/packaging` in the scheduled-daily-tasks workflow causes a Portage slot conflict, as it clashes with the specific `PYTHON_TARGETS` required by already-installed system packages (like `wheel` and `setuptools`). Removing it allows Portage to naturally resolve dependencies without conflict.

---
*PR created automatically by Jules for task [12316647149338655746](https://jules.google.com/task/12316647149338655746) started by @arran4*