### PR TITLE
Remove dev-lang/python from CI emerge to fix Portage slot conflict

### DIFF
--- a/.github/workflows/scheduled-daily-tasks.yml
+++ b/.github/workflows/scheduled-daily-tasks.yml
@@ -38,7 +38,7 @@ jobs:
           echo 'FEATURES="-ipc-sandbox -network-sandbox -pid-sandbox"' >> /etc/portage/make.conf
           mkdir -p /var/db/repos/gentoo
           emerge-webrsync
-          emerge --quiet app-portage/portage-utils dev-vcs/git dev-lang/python net-misc/curl app-misc/jq dev-util/github-cli
+          emerge --quiet app-portage/portage-utils dev-vcs/git net-misc/curl app-misc/jq dev-util/github-cli
 
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Removes `dev-lang/python` from the `emerge` command in `.github/workflows/scheduled-daily-tasks.yml` to prevent Portage slot conflicts in GitHub Actions. Python is a foundational package in Gentoo that comes pre-installed in the stage3 image. Asking Portage to install it explicitly on an un-updated image causes it to target the absolute latest Python slot, altering deep dependencies like `dev-python/packaging` and conflicting with pre-existing ones. Removing it resolves the CI build failure.

---
*PR created automatically by Jules for task [13204479183749794223](https://jules.google.com/task/13204479183749794223) started by @arran4*