### PR TITLE
fix(workflows): add explicit base branch to scheduled tasks PR

### DIFF
--- a/.github/workflows/scheduled-daily-tasks.yml
+++ b/.github/workflows/scheduled-daily-tasks.yml
@@ -159,6 +159,7 @@ jobs:
             </details>
           branch: "chore/scheduled-daily-tasks"
           delete-branch: true
+          base: main
 
   check-activity:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes the automated daily tasks workflow failing when creating the PR by specifying the target base branch as main.

---
*PR created automatically by Jules for task [8069035116542078274](https://jules.google.com/task/8069035116542078274) started by @arran4*