### PR TITLE
Fix 9999 live ebuild handling in remove_duplicate_ebuilds.py

### DIFF
--- a/scripts/remove_duplicate_ebuilds.py
+++ b/scripts/remove_duplicate_ebuilds.py
@@ -84,10 +84,13 @@ def process_ebuild(args):
     full_ver = ver if rev == "r0" else f"{ver}-{rev}"
     grade = "release"
     v_lower = ver.lower()
-    for tag in ("alpha", "beta", "rc", "pre", "test"):
-        if tag in v_lower:
-            grade = tag
-            break
+    if ver == "9999":
+        grade = "9999"
+    else:
+        for tag in ("alpha", "beta", "rc", "pre", "test"):
+            if tag in v_lower:
+                grade = tag
+                break
 
     return ((root, slot), grade, {
         "version": full_ver,
@@ -223,13 +226,20 @@ def main(repo_root):
 
         for pkg, vers in grouped_removed.items():
             rem_vers = grouped_remaining.get(pkg, [])
+
+            normal_rem_vers = [v for v in rem_vers if v != "9999"]
+            has_9999 = "9999" in rem_vers
+
             formatted_removed = ', '.join([f"-{v}" if not v.startswith('-') else v for v in sorted(vers, key=version_key)])
 
-            formatted_remaining = ', '.join([v for v in sorted(rem_vers, key=version_key)])
+            formatted_remaining = ', '.join([v for v in sorted(normal_rem_vers, key=version_key)])
+
+            live_note = " [has live 9999]" if has_9999 else ""
+
             if formatted_remaining:
-                print(f" - {pkg} (Removed: {formatted_removed} | Remaining: {formatted_remaining})")
+                print(f" - {pkg} (Removed: {formatted_removed} | Remaining: {formatted_remaining}){live_note}")
             else:
-                print(f" - {pkg} (Removed: {formatted_removed} | Remaining: None)")
+                print(f" - {pkg} (Removed: {formatted_removed} | Remaining: None){live_note}")
     else:
         print("No duplicates found")
 

--- a/scripts/remove_duplicate_ebuilds.py
+++ b/scripts/remove_duplicate_ebuilds.py
@@ -227,8 +227,8 @@ def main(repo_root):
         for pkg, vers in grouped_removed.items():
             rem_vers = grouped_remaining.get(pkg, [])
 
-            normal_rem_vers = [v for v in rem_vers if v != "9999"]
-            has_9999 = "9999" in rem_vers
+            normal_rem_vers = [v for v in rem_vers if v.split('-r')[0] != "9999"]
+            has_9999 = any(v.split('-r')[0] == "9999" for v in rem_vers)
 
             formatted_removed = ', '.join([f"-{v}" if not v.startswith('-') else v for v in sorted(vers, key=version_key)])
 


### PR DESCRIPTION
This updates the deduplication cleanup script to properly assign live ebuilds (version `9999`) to their own isolated grade. This prevents the script from accidentally removing non-live release versions because they are "older" than `9999` and updates the logging loop so they don't count towards standard remaining releases but are instead logged conditionally at the end of the printed output string.

---
*PR created automatically by Jules for task [16267894290091810232](https://jules.google.com/task/16267894290091810232) started by @arran4*