### PR TITLE
fix: explicitly checkout main for automated PRs

### DIFF
--- a/.github/workflows/scheduled-daily-tasks.yml
+++ b/.github/workflows/scheduled-daily-tasks.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: main
           fetch-depth: 0
 
       - name: Configure Overlay

--- a/.github/workflows/verify-manifests.yml
+++ b/.github/workflows/verify-manifests.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: main
           fetch-depth: 0
 
       - name: Install g2


### PR DESCRIPTION
Fixes GitHub Actions workflows failing during post-run cleanup when run on ephemeral branches by explicitly fetching the `main` branch.

---
*PR created automatically by Jules for task [16487891364241037688](https://jules.google.com/task/16487891364241037688) started by @arran4*