### PR TITLE
Fix shineyshot update workflow failing on empty releases

### DIFF
--- a/.github/workflows/app-misc-shineyshot-bin-update.yaml
+++ b/.github/workflows/app-misc-shineyshot-bin-update.yaml
@@ -1,3 +1,4 @@
+# Manually maintained because some releases lack assets (e.g. v1.0.4) breaking the automated workflow generator.
 # Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
 
 name: app-misc/shineyshot-bin update
@@ -74,7 +75,7 @@ jobs:
           EOF
           fi
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name") and (.assets | length > 0)) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"

--- a/current.config
+++ b/current.config
@@ -580,24 +580,6 @@ Binary x86=>tuios_${VERSION}_Linux_i386.tar.gz > tuios > tuios
 
 
 Type Github Binary Release
-GithubProjectUrl https://github.com/arran4/shineyshot
-Category app-misc
-EbuildName shineyshot-bin
-Description A simple screenshotting tool with several user modes
-Homepage https://github.com/arran4/shineyshot
-License GNU Affero General Public License v3.0
-ProgramName shineyshot
-Document amd64=>shineyshot_${VERSION}_Linux_x86_64.tar.gz > README.md > README.md
-Document arm=>shineyshot_${VERSION}_Linux_armv6.tar.gz > README.md > README.md
-Document arm=>shineyshot_${VERSION}_Linux_armv7.tar.gz > README.md > README.md
-Document arm64=>shineyshot_${VERSION}_Linux_arm64.tar.gz > README.md > README.md
-Document x86=>shineyshot_${VERSION}_Linux_i386.tar.gz > README.md > README.md
-Binary amd64=>shineyshot_${VERSION}_Linux_x86_64.tar.gz > shineyshot > shineyshot
-Binary arm=>shineyshot_${VERSION}_Linux_armv7.tar.gz > shineyshot > shineyshot
-Binary arm64=>shineyshot_${VERSION}_Linux_arm64.tar.gz > shineyshot > shineyshot
-Binary x86=>shineyshot_${VERSION}_Linux_i386.tar.gz > shineyshot > shineyshot
-
-Type Github Binary Release
 GithubProjectUrl https://github.com/arran4/flutter_jules
 Category app-misc
 EbuildName flutter-jules-bin.ebuild


### PR DESCRIPTION
Fix shineyshot update workflow failing on empty releases

- Modified .github/workflows/app-misc-shineyshot-bin-update.yaml to filter out releases that have no assets attached using jq `(.assets | length > 0)`. This solves the issue where the workflow would fail when trying to download assets for version `1.0.4`, which was an empty release.
- Removed shineyshot from `current.config` to prevent the automated generator from overwriting this manual fix.
- Added a comment to the workflow indicating it is now manually maintained.

---
*PR created automatically by Jules for task [8506791065624148913](https://jules.google.com/task/8506791065624148913) started by @arran4*