### PR TITLE
Fix im-hex-appimage installation failing on missing root icons

### DIFF
--- a/.github/workflows/dev-util-im-hex-appimage-update.yaml
+++ b/.github/workflows/dev-util-im-hex-appimage-update.yaml
@@ -120,7 +120,6 @@ jobs:
                 echo '  chmod a+x "${{ env.ImHex_appimage_installed_name }}"  || die "Can'\''t chmod archive file"'
                 echo '  "./${{ env.ImHex_appimage_installed_name }}" --appimage-extract "${{ env.ImHex_desktop_file }}" || die "Failed to extract .desktop from appimage"'
                 echo '  "./${{ env.ImHex_appimage_installed_name }}" --appimage-extract "usr/share/pixmaps" || die "Failed to extract pixmaps icons from app image"'
-                echo '  "./${{ env.ImHex_appimage_installed_name }}" --appimage-extract "*.png" || die "Failed to extract root icons from app image"'
                 echo '}'
                 echo ''
                 echo 'src_prepare() {'
@@ -135,8 +134,6 @@ jobs:
                 echo '  doins "squashfs-root/${{ env.ImHex_desktop_file }}" || die "Failed to install desktop file"'
                 echo '  insinto /usr/share/pixmaps'
                 echo '  doins squashfs-root/usr/share/pixmaps/*.png || die "Failed to install icons"'
-                echo '  insinto /usr/share/pixmaps'
-                echo '  doins squashfs-root/*.png || die "Failed to install icons"'
                 echo '}'
                 echo ""
                 echo "pkg_postinst() {"

--- a/current.config
+++ b/current.config
@@ -90,7 +90,7 @@ Homepage https://imhex.werwolv.net
 License GNU General Public License v2.0
 ProgramName ImHex
 DesktopFile imhex.desktop
-Icons pixmaps root
+Icons pixmaps
 Dependencies sys-libs/glibc sys-libs/zlib
 Binary amd64=>imhex-${VERSION}-x86_64.AppImage > ImHex.AppImage
 

--- a/dev-util/im-hex-appimage/im-hex-appimage-1.38.1.ebuild
+++ b/dev-util/im-hex-appimage/im-hex-appimage-1.38.1.ebuild
@@ -24,7 +24,6 @@ src_unpack() {
   chmod a+x "ImHex.AppImage"  || die "Can't chmod archive file"
   "./ImHex.AppImage" --appimage-extract "imhex.desktop" || die "Failed to extract .desktop from appimage"
   "./ImHex.AppImage" --appimage-extract "usr/share/pixmaps" || die "Failed to extract pixmaps icons from app image"
-  "./ImHex.AppImage" --appimage-extract "*.png" || die "Failed to extract root icons from app image"
 }
 
 src_prepare() {
@@ -39,8 +38,6 @@ src_install() {
   doins "squashfs-root/imhex.desktop" || die "Failed to install desktop file"
   insinto /usr/share/pixmaps
   doins squashfs-root/usr/share/pixmaps/*.png || die "Failed to install icons"
-  insinto /usr/share/pixmaps
-  doins squashfs-root/*.png || die "Failed to install icons"
 }
 
 pkg_postinst() {


### PR DESCRIPTION
This PR addresses an installation failure for `dev-util/im-hex-appimage` where `doins` failed with `FileNotFoundError: [Errno 2] No such file or directory: b'squashfs-root/*.png'`. The upstream AppImage no longer provides PNG icons in its root directory. I updated `current.config` to remove `root` from the `Icons` mapping, and modified both the current ebuild and the `.github/workflows/dev-util-im-hex-appimage-update.yaml` to remove the extraction and installation steps for root `.png` files. Pixmap icons are still properly installed.

---
*PR created automatically by Jules for task [4826571113576366502](https://jules.google.com/task/4826571113576366502) started by @arran4*