### PR TITLE
Fix missing ebuilds and workflows for kgithub-notify and game-device-udev-rules

### DIFF
--- a/.github/workflows/dev-vcs-kgithub-notify-update.yaml
+++ b/.github/workflows/dev-vcs-kgithub-notify-update.yaml
@@ -1,0 +1,95 @@
+name: Check and Update dev-vcs/kgithub-notify ebuilds
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  update-ebuild:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Install required tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq curl
+
+      - name: Setup g2
+        uses: arran4/g2-action@v1.2
+
+      - name: Check for new releases and create ebuild
+        run: |
+          set -e
+          LATEST_RELEASE=$(curl -s https://api.github.com/repos/arran4/kgithub-notify/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+          EBUILD_FILE="dev-vcs/kgithub-notify/kgithub-notify-${LATEST_RELEASE}.ebuild"
+
+          if [ -n "$LATEST_RELEASE" ] && [ "$LATEST_RELEASE" != "null" ]; then
+            if [ ! -f "$EBUILD_FILE" ]; then
+              echo "Creating ebuild for version $LATEST_RELEASE"
+
+              cat << 'EBUILD_EOF' > "$EBUILD_FILE"
+          # Copyright 2024 Gentoo Authors
+          # Distributed under the terms of the GNU General Public License v2
+
+          EAPI=8
+
+          inherit cmake xdg
+
+          DESCRIPTION="A GitHub notification tool for KDE/Qt"
+          HOMEPAGE="https://github.com/arran4/kgithub-notify"
+          SRC_URI="https://github.com/arran4/kgithub-notify/archive/refs/tags/v\${PV}.tar.gz -> \${P}.tar.gz"
+
+          LICENSE="BSD"
+          SLOT="0"
+          KEYWORDS="~amd64"
+          IUSE=""
+
+          DEPEND="
+		dev-qt/qtbase:6[dbus,gui,network,widgets]
+		dev-qt/qtsvg:6
+		kde-frameworks/kconfigwidgets:6
+		kde-frameworks/kcoreaddons:6
+		kde-frameworks/ki18n:6
+		kde-frameworks/knotifications:6
+		kde-frameworks/kwallet:6
+		kde-frameworks/kxmlgui:6
+          "
+          RDEPEND="\${DEPEND}"
+          BDEPEND="
+		dev-qt/qttools:6[linguist]
+		virtual/pkgconfig
+		kde-frameworks/extra-cmake-modules:0
+          "
+          EBUILD_EOF
+
+              sed -i 's/^          //' "$EBUILD_FILE"
+              sed -i 's/\${PV}/${PV}/g' "$EBUILD_FILE"
+              sed -i 's/\${P}/${P}/g' "$EBUILD_FILE"
+
+              echo "Generating Cache"
+              g2 cache generate dev-vcs/kgithub-notify
+              echo "Generating Manifest"
+              g2 manifest upsert-from-url "https://github.com/arran4/kgithub-notify/archive/refs/tags/v${LATEST_RELEASE}.tar.gz" "kgithub-notify-${LATEST_RELEASE}.tar.gz" dev-vcs/kgithub-notify
+            fi
+          fi
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update dev-vcs/kgithub-notify"
+          title: "Update dev-vcs/kgithub-notify"
+          body: |
+            Updates the ebuilds for `dev-vcs/kgithub-notify`.
+          branch: "update-dev-vcs-kgithub-notify"
+          base: "main"
+          delete-branch: true

--- a/.github/workflows/games-util-game-device-udev-rules-update.yaml
+++ b/.github/workflows/games-util-game-device-udev-rules-update.yaml
@@ -1,0 +1,90 @@
+name: Check and Update games-util/game-device-udev-rules ebuild
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  update-ebuild:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Install required tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq curl
+
+      - name: Setup g2
+        uses: arran4/g2-action@v1.2
+
+      - name: Check for new releases and create ebuild
+        run: |
+          set -e
+          LATEST_RELEASE=$(curl -s https://codeberg.org/api/v1/repos/fabiscafe/game-devices-udev/tags | jq -r '.[0].name' | sed 's/^v//')
+          EBUILD_FILE="games-util/game-device-udev-rules/game-device-udev-rules-${LATEST_RELEASE}.ebuild"
+
+          if [ -n "$LATEST_RELEASE" ] && [ "$LATEST_RELEASE" != "null" ]; then
+            if [ ! -f "$EBUILD_FILE" ]; then
+              echo "Creating ebuild for version $LATEST_RELEASE"
+
+              cat << 'EBUILD_EOF' > "$EBUILD_FILE"
+          # Copyright 2024 Gentoo Authors
+          # Distributed under the terms of the GNU General Public License v2
+
+          EAPI=8
+
+          inherit udev
+
+          DESCRIPTION="Udev rules for supported game controllers"
+          HOMEPAGE="https://codeberg.org/fabiscafe/game-devices-udev"
+          SRC_URI="https://codeberg.org/fabiscafe/game-devices-udev/archive/v\${PV}.tar.gz -> \${P}.tar.gz"
+
+          LICENSE="MIT"
+          SLOT="0"
+          KEYWORDS="~amd64"
+
+          DEPEND=""
+          RDEPEND="virtual/udev"
+
+          S="\${WORKDIR}/game-devices-udev"
+
+          src_install() {
+		udev_dorules *.rules
+          }
+
+          pkg_postinst() {
+		udev_reload
+          }
+          EBUILD_EOF
+
+              sed -i 's/^          //' "$EBUILD_FILE"
+              sed -i 's/\${PV}/${PV}/g' "$EBUILD_FILE"
+              sed -i 's/\${P}/${P}/g' "$EBUILD_FILE"
+              sed -i 's/\${WORKDIR}/${WORKDIR}/g' "$EBUILD_FILE"
+
+              echo "Updating manifest"
+              wget -q "https://codeberg.org/fabiscafe/game-devices-udev/archive/v${LATEST_RELEASE}.tar.gz" -O "game-device-udev-rules-${LATEST_RELEASE}.tar.gz"
+              g2 manifest upsert-from-url "https://codeberg.org/fabiscafe/game-devices-udev/archive/v${LATEST_RELEASE}.tar.gz" "game-device-udev-rules-${LATEST_RELEASE}.tar.gz" games-util/game-device-udev-rules
+            fi
+          fi
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update games-util/game-device-udev-rules"
+          title: "Update games-util/game-device-udev-rules"
+          body: |
+            Updates the ebuilds for `games-util/game-device-udev-rules`.
+          branch: "update-games-util-game-device-udev-rules"
+          base: "main"
+          delete-branch: true

--- a/dev-vcs/kgithub-notify/kgithub-notify-0.1.23.ebuild
+++ b/dev-vcs/kgithub-notify/kgithub-notify-0.1.23.ebuild
@@ -1,0 +1,32 @@
+# Copyright 2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake xdg
+
+DESCRIPTION="A GitHub notification tool for KDE/Qt"
+HOMEPAGE="https://github.com/arran4/kgithub-notify"
+SRC_URI="https://github.com/arran4/kgithub-notify/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE=""
+
+DEPEND="
+	dev-qt/qtbase:6[dbus,gui,network,widgets]
+	dev-qt/qtsvg:6
+	kde-frameworks/kconfigwidgets:6
+	kde-frameworks/kcoreaddons:6
+	kde-frameworks/ki18n:6
+	kde-frameworks/knotifications:6
+	kde-frameworks/kwallet:6
+	kde-frameworks/kxmlgui:6
+"
+RDEPEND="${DEPEND}"
+BDEPEND="
+	dev-qt/qttools:6[linguist]
+	virtual/pkgconfig
+	kde-frameworks/extra-cmake-modules:0
+"

--- a/games-util/game-device-udev-rules/metadata.xml
+++ b/games-util/game-device-udev-rules/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>gentoo@arran4.com</email>
+		<name>Arran Ubels</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="codeberg">fabiscafe/game-devices-udev</remote-id>
+	</upstream>
+</pkgmetadata>


### PR DESCRIPTION
- Resolves missing ebuilds issues for `dev-vcs/kgithub-notify` and `games-util/game-device-udev-rules`.
- Restores `dev-vcs/kgithub-notify` 0.1.23 release.
- Creates proper `.github/workflows/` files that use APIs to track tags on both github and codeberg to generate release ebuilds, bypassing the `current.config` since these need customized dependency handling and source paths.

---
*PR created automatically by Jules for task [10430823212331772898](https://jules.google.com/task/10430823212331772898) started by @arran4*