### PR TITLE
Fix which_browser update workflow version extraction

### DIFF
--- a/.github/workflows/www-misc-which_browser-update.yaml
+++ b/.github/workflows/www-misc-which_browser-update.yaml
@@ -53,7 +53,7 @@ jobs:
           # Scrape the XML for .deb filenames to capture full version including build suffix
           # This looks for patterns like which_browser-0.2.6+44-linux.deb
           # And handles HTML entity &#43; for +
-          filenames=$(curl -s "${{ env.base_url }}/index.xml" | grep -o 'which_browser-[0-9.]\+\(&#43;\|+\)[0-9]\+-linux.deb' | sed 's/&#43;/+/g' | sort -Vr | uniq)
+          filenames=$(curl -s "${{ env.base_url }}/index.xml" | grep -o 'which_browser-[0-9.]\+\(&amp;#43;\|&#43;\|+\)[0-9]\+-linux.deb' | sed 's/&amp;#43;/+/g;s/&#43;/+/g' | sort -Vr | uniq)
 
           for filename in $filenames; do
             # Extract version from filename: which_browser-0.2.6+44-linux.deb -> 0.2.6+44


### PR DESCRIPTION
The update workflow for `www-misc/which_browser` was failing to match any release tags containing `+` because the upstream XML feed began returning a double-encoded `&amp;#43;` entity. This fix updates the `grep` regex and subsequent `sed` replacement string to catch and decode `&amp;#43;`, `&#43;`, and literal `+` correctly, enabling automatic ebuild updates once again.

---
*PR created automatically by Jules for task [13721827999483956675](https://jules.google.com/task/13721827999483956675) started by @arran4*