### PR TITLE
chore: update scheduled daily tasks to run at 5:30am AEST

### DIFF
--- a/.github/workflows/scheduled-daily-tasks.yml
+++ b/.github/workflows/scheduled-daily-tasks.yml
@@ -8,7 +8,7 @@ permissions:
 
 on:
   schedule:
-    - cron: '0 19 * * *'
+    - cron: '30 19 * * *'
   workflow_dispatch:
     inputs:
       g2_version:


### PR DESCRIPTION
This modifies the `.github/workflows/scheduled-daily-tasks.yml` to change the `cron` schedule from `0 19 * * *` to `30 19 * * *`. This schedules the job for 5:30 AM AEST (UTC+10), which accurately fulfills the requirement to run between 5-6 AM AEST and prevents it from running exactly on the hour, which is better for GitHub Actions scheduling.

---
*PR created automatically by Jules for task [16823983375295495313](https://jules.google.com/task/16823983375295495313) started by @arran4*