### PR TITLE
Update daily tasks schedule to 5am AEST

### DIFF
--- a/.github/workflows/scheduled-daily-tasks.yml
+++ b/.github/workflows/scheduled-daily-tasks.yml
@@ -8,7 +8,7 @@ permissions:
 
 on:
   schedule:
-    - cron: '30 19 * * *'
+    - cron: '0 19 * * *'
   workflow_dispatch:
     inputs:
       g2_version:


### PR DESCRIPTION
Updates the scheduled-daily-tasks.yml cron schedule to run at exactly 5am Australian AEST (UTC 19:00).

---
*PR created automatically by Jules for task [5173555231247726805](https://jules.google.com/task/5173555231247726805) started by @arran4*