### PR TITLE
Add polkit-systemd-mariadb-control package

### DIFF
--- a/app-admin/polkit-systemd-mariadb-control/files/50-systemctl-mariadb.rules
+++ b/app-admin/polkit-systemd-mariadb-control/files/50-systemctl-mariadb.rules
@@ -1,0 +1,17 @@
+/* Allow members of the systemctl-operators group to start, stop, and restart mariadb.service */
+
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.freedesktop.systemd1.manage-units" &&
+        subject.isInGroup("systemctl-operators") &&
+        subject.local &&
+        subject.active) {
+
+        var unit = action.lookup("unit");
+        var verb = action.lookup("verb");
+
+        if (unit == "mariadb.service" &&
+            (verb == "start" || verb == "stop" || verb == "restart")) {
+            return polkit.Result.YES;
+        }
+    }
+});

--- a/app-admin/polkit-systemd-mariadb-control/metadata.xml
+++ b/app-admin/polkit-systemd-mariadb-control/metadata.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>gentoo@arran4.com</email>
+		<name>Arran Ubels</name>
+	</maintainer>
+	<longdescription lang="en">Polkit rules to allow the systemctl-operators group to manage mariadb.service</longdescription>
+</pkgmetadata>

--- a/app-admin/polkit-systemd-mariadb-control/polkit-systemd-mariadb-control-0.ebuild
+++ b/app-admin/polkit-systemd-mariadb-control/polkit-systemd-mariadb-control-0.ebuild
@@ -8,7 +8,7 @@ HOMEPAGE="https://github.com/arran4/arrans-overlay"
 SRC_URI=""
 S="${WORKDIR}"
 
-LICENSE="metapackage"
+LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64"
 

--- a/app-admin/polkit-systemd-mariadb-control/polkit-systemd-mariadb-control-0.ebuild
+++ b/app-admin/polkit-systemd-mariadb-control/polkit-systemd-mariadb-control-0.ebuild
@@ -1,0 +1,31 @@
+# Copyright 2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Polkit rules for systemctl control of mariadb.service"
+HOMEPAGE="https://github.com/arran4/arrans-overlay"
+SRC_URI=""
+S="${WORKDIR}"
+
+LICENSE="metapackage"
+SLOT="0"
+KEYWORDS="~amd64"
+
+RDEPEND="
+	sys-auth/polkit
+	acct-group/systemctl-operators
+"
+
+src_install() {
+	insinto /etc/polkit-1/rules.d
+	doins "${FILESDIR}/50-systemctl-mariadb.rules"
+}
+
+pkg_postinst() {
+	elog "The Polkit policy for mariadb.service was installed."
+	elog "To allow a user to use these delegated rules, add them to the systemctl-operators group:"
+	elog "gpasswd -a <username> systemctl-operators"
+	elog ""
+	elog "Users must log out and log back in for group membership to apply."
+}


### PR DESCRIPTION
Creates a new Gentoo ebuild `app-admin/polkit-systemd-mariadb-control` that provides Polkit rules to delegate control of `mariadb.service` to the `systemctl-operators` group.

---
*PR created automatically by Jules for task [12376905869939781740](https://jules.google.com/task/12376905869939781740) started by @arran4*