### PR TITLE
chore: update scheduled daily tasks triggers

### DIFF
--- a/.github/workflows/scheduled-daily-tasks.yml
+++ b/.github/workflows/scheduled-daily-tasks.yml
@@ -9,6 +9,16 @@ permissions:
 on:
   schedule:
     - cron: '0 19 * * *'
+  workflow_dispatch:
+    inputs:
+      g2_version:
+        description: 'Version of g2 to use'
+        required: false
+        default: 'latest'
+        type: string
+  push:
+    paths:
+      - '.github/workflows/scheduled-daily-tasks.yml'
 
 jobs:
   scheduled-tasks:

--- a/.github/workflows/scheduled-daily-tasks.yml
+++ b/.github/workflows/scheduled-daily-tasks.yml
@@ -8,21 +8,7 @@ permissions:
 
 on:
   schedule:
-    - cron: '30 19 * * *'
-  workflow_dispatch:
-    inputs:
-      g2_version:
-        description: 'Version of g2 to use'
-        required: false
-        default: 'latest'
-        type: string
-  push:
-    paths:
-      - '.github/workflows/scheduled-daily-tasks.yml'
-  workflow_run:
-    workflows: ["app-admin/g2-bin update"]
-    types:
-      - completed
+    - cron: '0 19 * * *'
 
 jobs:
   scheduled-tasks:


### PR DESCRIPTION
- Modified `.github/workflows/scheduled-daily-tasks.yml` to remove all triggers except `schedule`.
- Updated cron expression to `0 19 * * *` (exactly 5am AEST) per user's request.

---
*PR created automatically by Jules for task [14956715646540606411](https://jules.google.com/task/14956715646540606411) started by @arran4*