### PR TITLE
Fix duplicate ebuild output version listings

### DIFF
--- a/scripts/remove_duplicate_ebuilds.py
+++ b/scripts/remove_duplicate_ebuilds.py
@@ -230,7 +230,10 @@ def main(repo_root):
             normal_rem_vers = [v for v in rem_vers if v.split('-r')[0] != "9999"]
             has_9999 = any(v.split('-r')[0] == "9999" for v in rem_vers)
 
-            formatted_removed = ', '.join([f"-{v}" if not v.startswith('-') else v for v in sorted(set(vers), key=version_key)])
+            formatted_removed = ', '.join(
+                f"-{v}" if not v.startswith('-') else v
+                for v in sorted(set(vers), key=version_key)
+            )
 
             formatted_remaining = ', '.join(sorted(set(normal_rem_vers), key=version_key))
 

--- a/scripts/remove_duplicate_ebuilds.py
+++ b/scripts/remove_duplicate_ebuilds.py
@@ -230,9 +230,9 @@ def main(repo_root):
             normal_rem_vers = [v for v in rem_vers if v.split('-r')[0] != "9999"]
             has_9999 = any(v.split('-r')[0] == "9999" for v in rem_vers)
 
-            formatted_removed = ', '.join([f"-{v}" if not v.startswith('-') else v for v in sorted(vers, key=version_key)])
+            formatted_removed = ', '.join([f"-{v}" if not v.startswith('-') else v for v in sorted(set(vers), key=version_key)])
 
-            formatted_remaining = ', '.join([v for v in sorted(normal_rem_vers, key=version_key)])
+            formatted_remaining = ', '.join(sorted(set(normal_rem_vers), key=version_key))
 
             live_note = " [has live 9999]" if has_9999 else ""
 


### PR DESCRIPTION
Remove duplicate version listings from the "Removed" and "Remaining" output lines by wrapping the version lists with `set()` before formatting the strings in `scripts/remove_duplicate_ebuilds.py`.

This resolves the issue where remaining versions would output duplicate elements when multiple duplicate items triggered loop tracking.

---
*PR created automatically by Jules for task [10164780774922351072](https://jules.google.com/task/10164780774922351072) started by @arran4*