### PR TITLE
Fix app-misc/ollama-bin install error caused by doexe -r

### DIFF
--- a/.github/workflows/app-misc-ollama-bin-update.yaml
+++ b/.github/workflows/app-misc-ollama-bin-update.yaml
@@ -136,8 +136,8 @@ jobs:
                 echo '  exeinto /opt/Ollama/bin'
                 echo '  doexe "${WORKDIR}/bin/ollama" || die "Failed to install binary"'
                 echo '  insinto /opt/Ollama/lib'
-                echo '  doins -r "${WORKDIR}/lib/ollama/" || die "Failed to install libraries"'
-                echo '  chmod +x -R "${ED}/opt/Ollama/lib/ollama/" || die'
+                echo '  doins -r "${WORKDIR}/lib/ollama/"'
+                echo '  fperms -R +x /opt/Ollama/lib/ollama/'
                 echo '  dosym /opt/Ollama/bin/ollama /opt/bin/ollama'
                 echo "}"
                 echo ""

--- a/.github/workflows/app-misc-ollama-bin-update.yaml
+++ b/.github/workflows/app-misc-ollama-bin-update.yaml
@@ -135,8 +135,9 @@ jobs:
                 echo "src_install() {"
                 echo '  exeinto /opt/Ollama/bin'
                 echo '  doexe "${WORKDIR}/bin/ollama" || die "Failed to install binary"'
-                echo '  exeinto /opt/Ollama/lib'
-                echo '  doexe -r "${WORKDIR}/lib/ollama/" || die "Failed to install libraries"'
+                echo '  insinto /opt/Ollama/lib'
+                echo '  doins -r "${WORKDIR}/lib/ollama/" || die "Failed to install libraries"'
+                echo '  chmod +x -R "${ED}/opt/Ollama/lib/ollama/" || die'
                 echo '  dosym /opt/Ollama/bin/ollama /opt/bin/ollama'
                 echo "}"
                 echo ""

--- a/app-misc/ollama-bin/ollama-bin-0.31.1.ebuild
+++ b/app-misc/ollama-bin/ollama-bin-0.31.1.ebuild
@@ -36,8 +36,8 @@ src_install() {
   exeinto /opt/Ollama/bin
   doexe "${WORKDIR}/bin/ollama" || die "Failed to install binary"
   insinto /opt/Ollama/lib
-  doins -r "${WORKDIR}/lib/ollama/" || die "Failed to install libraries"
-  chmod +x -R "${ED}/opt/Ollama/lib/ollama/" || die
+  doins -r "${WORKDIR}/lib/ollama/"
+  fperms -R +x /opt/Ollama/lib/ollama/
   dosym /opt/Ollama/bin/ollama /opt/bin/ollama
 }
 

--- a/app-misc/ollama-bin/ollama-bin-0.31.1.ebuild
+++ b/app-misc/ollama-bin/ollama-bin-0.31.1.ebuild
@@ -35,8 +35,9 @@ src_unpack() {
 src_install() {
   exeinto /opt/Ollama/bin
   doexe "${WORKDIR}/bin/ollama" || die "Failed to install binary"
-  exeinto /opt/Ollama/lib
-  doexe -r "${WORKDIR}/lib/ollama/" || die "Failed to install libraries"
+  insinto /opt/Ollama/lib
+  doins -r "${WORKDIR}/lib/ollama/" || die "Failed to install libraries"
+  chmod +x -R "${ED}/opt/Ollama/lib/ollama/" || die
   dosym /opt/Ollama/bin/ollama /opt/bin/ollama
 }
 


### PR DESCRIPTION
Fix app-misc/ollama-bin install error caused by doexe -r

---
*PR created automatically by Jules for task [6361515339143829850](https://jules.google.com/task/6361515339143829850) started by @arran4*