### PR TITLE
app-misc/ollama-bin: fix doexe -r error in src_install

### DIFF
--- a/.github/workflows/app-misc-ollama-bin-update.yaml
+++ b/.github/workflows/app-misc-ollama-bin-update.yaml
@@ -136,8 +136,8 @@ jobs:
                 echo '  exeinto /opt/Ollama/bin'
                 echo '  doexe "${WORKDIR}/bin/ollama" || die "Failed to install binary"'
                 echo '  insinto /opt/Ollama/lib'
-                echo '  doins -r "${WORKDIR}/lib/ollama" || die "Failed to install libraries"'
-                echo '  find "${ED}/opt/Ollama/lib/ollama" -type f -name "*.so*" -exec chmod +x {} + || die "Failed to make libraries executable"'
+                echo '  doins -r "${WORKDIR}/lib/ollama/"'
+                echo '  fperms -R +x /opt/Ollama/lib/ollama'
                 echo '  dosym /opt/Ollama/bin/ollama /opt/bin/ollama'
                 echo "}"
                 echo ""

--- a/.github/workflows/app-misc-ollama-bin-update.yaml
+++ b/.github/workflows/app-misc-ollama-bin-update.yaml
@@ -135,10 +135,9 @@ jobs:
                 echo "src_install() {"
                 echo '  exeinto /opt/Ollama/bin'
                 echo '  doexe "${WORKDIR}/bin/ollama" || die "Failed to install binary"'
-                echo '  exeinto /opt/Ollama/lib'
-                echo '  for f in "${WORKDIR}/lib/ollama/"*; do'
-                echo '    doexe "$f"'
-                echo '  done'
+                echo '  insinto /opt/Ollama/lib'
+                echo '  doins -r "${WORKDIR}/lib/ollama" || die "Failed to install libraries"'
+                echo '  find "${ED}/opt/Ollama/lib/ollama" -type f -name "*.so*" -exec chmod +x {} + || die "Failed to make libraries executable"'
                 echo '  dosym /opt/Ollama/bin/ollama /opt/bin/ollama'
                 echo "}"
                 echo ""

--- a/.github/workflows/app-misc-ollama-bin-update.yaml
+++ b/.github/workflows/app-misc-ollama-bin-update.yaml
@@ -135,8 +135,9 @@ jobs:
                 echo "src_install() {"
                 echo '  exeinto /opt/Ollama/bin'
                 echo '  doexe "${WORKDIR}/bin/ollama" || die "Failed to install binary"'
-                echo '  exeinto /opt/Ollama/lib'
-                echo '  doexe -r "${WORKDIR}/lib/ollama/" || die "Failed to install libraries"'
+                echo '  insinto /opt/Ollama/lib'
+                echo '  doins -r "${WORKDIR}/lib/ollama/" || die "Failed to install libraries"'
+                echo '  chmod +x -R "${ED}/opt/Ollama/lib/ollama" || die "Failed to make libraries executable"'
                 echo '  dosym /opt/Ollama/bin/ollama /opt/bin/ollama'
                 echo "}"
                 echo ""

--- a/.github/workflows/app-misc-ollama-bin-update.yaml
+++ b/.github/workflows/app-misc-ollama-bin-update.yaml
@@ -135,9 +135,10 @@ jobs:
                 echo "src_install() {"
                 echo '  exeinto /opt/Ollama/bin'
                 echo '  doexe "${WORKDIR}/bin/ollama" || die "Failed to install binary"'
-                echo '  insinto /opt/Ollama/lib'
-                echo '  doins -r "${WORKDIR}/lib/ollama/" || die "Failed to install libraries"'
-                echo '  chmod +x -R "${ED}/opt/Ollama/lib/ollama" || die "Failed to make libraries executable"'
+                echo '  exeinto /opt/Ollama/lib'
+                echo '  for f in "${WORKDIR}/lib/ollama/"*; do'
+                echo '    doexe "$f"'
+                echo '  done'
                 echo '  dosym /opt/Ollama/bin/ollama /opt/bin/ollama'
                 echo "}"
                 echo ""

--- a/app-misc/ollama-bin/ollama-bin-0.31.1.ebuild
+++ b/app-misc/ollama-bin/ollama-bin-0.31.1.ebuild
@@ -35,8 +35,9 @@ src_unpack() {
 src_install() {
   exeinto /opt/Ollama/bin
   doexe "${WORKDIR}/bin/ollama" || die "Failed to install binary"
-  exeinto /opt/Ollama/lib
-  doexe -r "${WORKDIR}/lib/ollama/" || die "Failed to install libraries"
+  insinto /opt/Ollama/lib
+  doins -r "${WORKDIR}/lib/ollama/" || die "Failed to install libraries"
+  chmod +x -R "${ED}/opt/Ollama/lib/ollama" || die "Failed to make libraries executable"
   dosym /opt/Ollama/bin/ollama /opt/bin/ollama
 }
 

--- a/app-misc/ollama-bin/ollama-bin-0.31.1.ebuild
+++ b/app-misc/ollama-bin/ollama-bin-0.31.1.ebuild
@@ -36,8 +36,8 @@ src_install() {
   exeinto /opt/Ollama/bin
   doexe "${WORKDIR}/bin/ollama" || die "Failed to install binary"
   insinto /opt/Ollama/lib
-  doins -r "${WORKDIR}/lib/ollama"
-  find "${ED}/opt/Ollama/lib/ollama" -type f -name "*.so*" -exec chmod +x {} +
+  doins -r "${WORKDIR}/lib/ollama" || die "Failed to install libraries"
+  find "${ED}/opt/Ollama/lib/ollama" -type f -name "*.so*" -exec chmod +x {} + || die "Failed to make libraries executable"
   dosym /opt/Ollama/bin/ollama /opt/bin/ollama
 }
 

--- a/app-misc/ollama-bin/ollama-bin-0.31.1.ebuild
+++ b/app-misc/ollama-bin/ollama-bin-0.31.1.ebuild
@@ -35,9 +35,10 @@ src_unpack() {
 src_install() {
   exeinto /opt/Ollama/bin
   doexe "${WORKDIR}/bin/ollama" || die "Failed to install binary"
-  insinto /opt/Ollama/lib
-  doins -r "${WORKDIR}/lib/ollama/" || die "Failed to install libraries"
-  chmod +x -R "${ED}/opt/Ollama/lib/ollama" || die "Failed to make libraries executable"
+  exeinto /opt/Ollama/lib
+  for f in "${WORKDIR}/lib/ollama/"*; do
+    doexe "$f"
+  done
   dosym /opt/Ollama/bin/ollama /opt/bin/ollama
 }
 

--- a/app-misc/ollama-bin/ollama-bin-0.31.1.ebuild
+++ b/app-misc/ollama-bin/ollama-bin-0.31.1.ebuild
@@ -36,8 +36,8 @@ src_install() {
   exeinto /opt/Ollama/bin
   doexe "${WORKDIR}/bin/ollama" || die "Failed to install binary"
   insinto /opt/Ollama/lib
-  doins -r "${WORKDIR}/lib/ollama" || die "Failed to install libraries"
-  find "${ED}/opt/Ollama/lib/ollama" -type f -name "*.so*" -exec chmod +x {} + || die "Failed to make libraries executable"
+  doins -r "${WORKDIR}/lib/ollama/"
+  fperms -R +x /opt/Ollama/lib/ollama
   dosym /opt/Ollama/bin/ollama /opt/bin/ollama
 }
 

--- a/app-misc/ollama-bin/ollama-bin-0.31.1.ebuild
+++ b/app-misc/ollama-bin/ollama-bin-0.31.1.ebuild
@@ -35,10 +35,9 @@ src_unpack() {
 src_install() {
   exeinto /opt/Ollama/bin
   doexe "${WORKDIR}/bin/ollama" || die "Failed to install binary"
-  exeinto /opt/Ollama/lib
-  for f in "${WORKDIR}/lib/ollama/"*; do
-    doexe "$f"
-  done
+  insinto /opt/Ollama/lib
+  doins -r "${WORKDIR}/lib/ollama"
+  find "${ED}/opt/Ollama/lib/ollama" -type f -name "*.so*" -exec chmod +x {} +
   dosym /opt/Ollama/bin/ollama /opt/bin/ollama
 }
 


### PR DESCRIPTION
Replace invalid doexe -r with doins -r and chmod +x -R to correctly recursively install libraries in app-misc/ollama-bin-0.31.1.ebuild and the github update workflow generator.

---
*PR created automatically by Jules for task [12539097703159186693](https://jules.google.com/task/12539097703159186693) started by @arran4*