### PR TITLE
app-admin/sudoers-emerge: Add dispatch-conf to NOPASSWD

### DIFF
--- a/app-admin/sudoers-emerge/files/10-emerge
+++ b/app-admin/sudoers-emerge/files/10-emerge
@@ -1,1 +1,1 @@
-%wheel ALL=(ALL:ALL) NOPASSWD: /usr/bin/emerge --sync, /usr/bin/emerge -avuDNU --with-bdeps=y @world --keep-going=y
+%wheel ALL=(ALL:ALL) NOPASSWD: /usr/bin/emerge --sync, /usr/bin/emerge -avuDNU --with-bdeps=y @world --keep-going=y, /usr/sbin/dispatch-conf


### PR DESCRIPTION
Added `/usr/sbin/dispatch-conf` to the `NOPASSWD` list in `10-emerge` to allow `%wheel` members to run it without a password prompt.

---
*PR created automatically by Jules for task [2310732592519521343](https://jules.google.com/task/2310732592519521343) started by @arran4*