### PR TITLE
Update dedupe parsing logic

### DIFF
--- a/.github/workflows/scheduled-daily-tasks.yml
+++ b/.github/workflows/scheduled-daily-tasks.yml
@@ -86,6 +86,7 @@ jobs:
         run: |
           python3 <<'PY' > /tmp/pr_summary.md
           import os
+          import re
           import subprocess
           from collections import defaultdict
 
@@ -120,7 +121,21 @@ jobs:
               for raw_line in dedupe_output.splitlines():
                   line = raw_line.strip()
                   if line.startswith("- "):
-                      dedupe_lines.append(f"- `{line[2:]}`")
+                      m = re.match(r"- (.*?) \(Removed: (.*?) \| Remaining: (.*?)\)(.*)", line)
+                      if m:
+                          pkg = m.group(1)
+                          removed = m.group(2)
+                          remaining = m.group(3)
+                          rest = m.group(4)
+                          pkg_fmt = f"`{pkg}`"
+                          removed_fmt = ", ".join(f"`{v.strip()}`" for v in removed.split(","))
+                          if remaining == "None":
+                              remaining_fmt = "None"
+                          else:
+                              remaining_fmt = ", ".join(f"`{v.strip()}`" for v in remaining.split(","))
+                          dedupe_lines.append(f"- {pkg_fmt} (Removed: {removed_fmt} | Remaining: {remaining_fmt}){rest}")
+                      else:
+                          dedupe_lines.append(f"- `{line[2:]}`")
           print_section("Duplicate ebuilds removed", dedupe_lines)
 
           egencache_rows = changed_paths(["--", "metadata/md5-cache"])


### PR DESCRIPTION
Updated the parsing logic in `.github/workflows/scheduled-daily-tasks.yml` to apply markdown code quotes only to the package name and version numbers in the deduplication output, rather than quoting the entire line. This makes the output much more readable.

---
*PR created automatically by Jules for task [3828462392354173579](https://jules.google.com/task/3828462392354173579) started by @arran4*