### PR TITLE
Fix missing qdbus USE flag in qttools for kgithub-notify

### DIFF
--- a/.github/workflows/dev-vcs-kgithub-notify-update.yaml
+++ b/.github/workflows/dev-vcs-kgithub-notify-update.yaml
@@ -113,7 +113,7 @@ jobs:
                 echo '"'
                 echo 'BDEPEND="'
                 echo '	>=kde-frameworks/extra-cmake-modules-${KFMIN}:0'
-                echo '	dev-qt/qttools:6'
+                echo '	dev-qt/qttools:6[qdbus]'
                 echo '"'
               } > $ebuild_file
 

--- a/dev-vcs/kgithub-notify/kgithub-notify-0.1.26.ebuild
+++ b/dev-vcs/kgithub-notify/kgithub-notify-0.1.26.ebuild
@@ -30,5 +30,5 @@ DEPEND="${RDEPEND}
 "
 BDEPEND="
 	>=kde-frameworks/extra-cmake-modules-${KFMIN}:0
-	dev-qt/qttools:6
+	dev-qt/qttools:6[qdbus]
 "


### PR DESCRIPTION
This PR updates the `dev-vcs/kgithub-notify/kgithub-notify-0.1.26.ebuild` and its corresponding GitHub Actions workflow script `.github/workflows/dev-vcs-kgithub-notify-update.yaml` to include the `[qdbus]` USE flag on the `dev-qt/qttools:6` build dependency.

This resolves potential build failures on Gentoo where the `qdbusxml2cpp` DBus code generation tool is not installed by default unless the `qdbus` USE flag is enabled for `qttools`.

---
*PR created automatically by Jules for task [6343078623530086913](https://jules.google.com/task/6343078623530086913) started by @arran4*