### PR TITLE
docs: update AGENTS.md with major changes and ebuild removal policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,3 +66,8 @@ To keep the overlay clean, we follow a **"One Version Per Grade"** policy.
 
 *   **Scope Restriction:** All pull requests, unless otherwise specified, are to be restricted to changes strictly necessary to meet the primary goals of the PR.
 *   **CI Failures:** This restriction applies even if CI failures occur. Do not attempt to fix unrelated CI failures unless explicitly instructed by the user to do so.
+
+## 7. Major Changes & Ebuild Removal
+
+*   When removing entire ebuilds and workflows or making major changes to the repository or how things work, you must add Gentoo news.
+*   This news must be clearly authored from me and/or +ai.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,5 +69,5 @@ To keep the overlay clean, we follow a **"One Version Per Grade"** policy.
 
 ## 7. Major Changes & Ebuild Removal
 
-*   When removing entire ebuilds and workflows or making major changes to the repository or how things work, you must add Gentoo news.
+*   When removing entire ebuilds and workflows or making major changes to the repository or how things work, you must add arrans_overlay news.
 *   This news must be clearly authored from me and/or +ai.


### PR DESCRIPTION
Updated AGENTS.md to add a new section explicitly instructing that any major changes to the repository or the removal of entire ebuilds/workflows must include a Gentoo news announcement authored by the user and/or +ai.

---
*PR created automatically by Jules for task [5040691756942246245](https://jules.google.com/task/5040691756942246245) started by @arran4*