### PR TITLE
Fix Antigravity bin download URL extraction logic

### DIFF
--- a/.github/workflows/dev-util-antigravity-bin-update.yaml
+++ b/.github/workflows/dev-util-antigravity-bin-update.yaml
@@ -61,20 +61,11 @@ jobs:
           fi
 
           curl -sL --compressed -A "Mozilla/5.0" https://antigravity.google/download > /tmp/index.html
-          main_js=$(grep -o 'main-[^"]*\.js' /tmp/index.html | head -n 1 | tr -d '\r')
-          echo "main_js: $main_js"
-          if [ -z "$main_js" ]; then
-            echo "Could not find main_js. First 500 bytes of index.html:"
-            head -c 500 /tmp/index.html
-            exit 1
-          fi
-
-          curl -sL --compressed -A "Mozilla/5.0" "https://antigravity.google/$main_js" > /tmp/main.js
-          download_url=$(grep -io 'https://[a-zA-Z0-9./_-]*antigravity\.tar\.gz' /tmp/main.js | head -n 1 | tr -d '\r')
+          download_url=$(grep -ioE 'https://[^"<>]*linux-x64/Antigravity\.tar\.gz' /tmp/index.html | head -n 1 | tr -d '\r')
           echo "download_url: $download_url"
           if [ -z "$download_url" ]; then
-            echo "Could not find download_url. First 500 bytes of main.js:"
-            head -c 500 /tmp/main.js
+            echo "Could not find download_url. First 500 bytes of index.html:"
+            head -c 500 /tmp/index.html
             exit 1
           fi
 


### PR DESCRIPTION
Update `.github/workflows/dev-util-antigravity-bin-update.yaml` to handle changes to the Antigravity download website structure, extracting the download URL directly from `index.html` instead of a dynamically loaded JavaScript file.

---
*PR created automatically by Jules for task [15899058170290066733](https://jules.google.com/task/15899058170290066733) started by @arran4*