### PR TITLE
Fix missing HOMEPAGE and undocumented USE flag

### DIFF
--- a/app-misc/kjules/metadata.xml
+++ b/app-misc/kjules/metadata.xml
@@ -8,4 +8,7 @@
   <upstream>
     <remote-id type="github">arran4/kjules</remote-id>
   </upstream>
+  <use>
+    <flag name="debug">Enable debug mode</flag>
+  </use>
 </pkgmetadata>

--- a/app-misc/maid-appimage/maid-appimage-1.3.1.ebuild
+++ b/app-misc/maid-appimage/maid-appimage-1.3.1.ebuild
@@ -1,7 +1,7 @@
 # Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/app-misc-maid-appimage-update.yaml
 EAPI=8
 DESCRIPTION="Maid is a cross-platform Flutter app for interfacing with GGUF / llama.cpp models locally, and with Ollama and OpenAI models remotely."
-HOMEPAGE=""
+HOMEPAGE="https://github.com/Mobile-Artificial-Intelligence/maid"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64"

--- a/gap.md
+++ b/gap.md
@@ -1,4 +1,4 @@
 ## arrans_overlay_workflow_builder gap
 
-The `overlay_workflow_builder_generator` does not currently generate `HOMEPAGE` in the github-appimage generated workflows based on the `Homepage` configuration in `current.config`, which results in empty `HOMEPAGE=""` in generated ebuilds. Also for Github Binary Release, if the Homepage is defined, it is completely ignored resulting in missing HOMEPAGE in ebuilds.
+As of version 0.1.28 and 2026-07-25, the `overlay_workflow_builder_generator` does not currently generate `HOMEPAGE` in the github-appimage generated workflows based on the `Homepage` configuration in `current.config`, which results in empty `HOMEPAGE=""` in generated ebuilds. Also for Github Binary Release, if the Homepage is defined, it is completely ignored resulting in missing HOMEPAGE in ebuilds.
 Please add support for injecting the `HOMEPAGE` value defined in `current.config` directly into the generated ebuilds for both AppImage and Binary Release templates.

--- a/gap.md
+++ b/gap.md
@@ -1,0 +1,4 @@
+## arrans_overlay_workflow_builder gap
+
+The `overlay_workflow_builder_generator` does not currently generate `HOMEPAGE` in the github-appimage generated workflows based on the `Homepage` configuration in `current.config`, which results in empty `HOMEPAGE=""` in generated ebuilds. Also for Github Binary Release, if the Homepage is defined, it is completely ignored resulting in missing HOMEPAGE in ebuilds.
+Please add support for injecting the `HOMEPAGE` value defined in `current.config` directly into the generated ebuilds for both AppImage and Binary Release templates.

--- a/gap.md
+++ b/gap.md
@@ -1,4 +1,0 @@
-## arrans_overlay_workflow_builder gap
-
-As of version 0.1.28 and 2026-07-25, the `overlay_workflow_builder_generator` does not currently generate `HOMEPAGE` in the github-appimage generated workflows based on the `Homepage` configuration in `current.config`, which results in empty `HOMEPAGE=""` in generated ebuilds. Also for Github Binary Release, if the Homepage is defined, it is completely ignored resulting in missing HOMEPAGE in ebuilds.
-Please add support for injecting the `HOMEPAGE` value defined in `current.config` directly into the generated ebuilds for both AppImage and Binary Release templates.

--- a/net-im/slackdump-bin/slackdump-bin-4.4.2.ebuild
+++ b/net-im/slackdump-bin/slackdump-bin-4.4.2.ebuild
@@ -2,7 +2,6 @@
 EAPI=8
 DESCRIPTION="Save or export your private and public Slack messages, threads, files, and users locally without admin privileges."
 HOMEPAGE="https://github.com/rusq/slackdump"
-HOMEPAGE=""
 SRC_URI="
   amd64? (  https://github.com/rusq/slackdump/releases/download/v${PV}/slackdump_Linux_x86_64.tar.gz -> ${P}-slackdump_Linux_x86_64.tar.gz  )  
   arm64? (  https://github.com/rusq/slackdump/releases/download/v${PV}/slackdump_Linux_arm64.tar.gz -> ${P}-slackdump_Linux_arm64.tar.gz  )  

--- a/net-im/slackdump-bin/slackdump-bin-4.4.2.ebuild
+++ b/net-im/slackdump-bin/slackdump-bin-4.4.2.ebuild
@@ -2,6 +2,7 @@
 EAPI=8
 DESCRIPTION="Save or export your private and public Slack messages, threads, files, and users locally without admin privileges."
 HOMEPAGE="https://github.com/rusq/slackdump"
+HOMEPAGE=""
 SRC_URI="
   amd64? (  https://github.com/rusq/slackdump/releases/download/v${PV}/slackdump_Linux_x86_64.tar.gz -> ${P}-slackdump_Linux_x86_64.tar.gz  )  
   arm64? (  https://github.com/rusq/slackdump/releases/download/v${PV}/slackdump_Linux_arm64.tar.gz -> ${P}-slackdump_Linux_arm64.tar.gz  )  

--- a/net-im/slackdump-bin/slackdump-bin-4.4.2.ebuild
+++ b/net-im/slackdump-bin/slackdump-bin-4.4.2.ebuild
@@ -1,7 +1,7 @@
 # Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/net-im-slackdump-bin-update.yaml
 EAPI=8
 DESCRIPTION="Save or export your private and public Slack messages, threads, files, and users locally without admin privileges."
-HOMEPAGE=""
+HOMEPAGE="https://github.com/rusq/slackdump"
 SRC_URI="
   amd64? (  https://github.com/rusq/slackdump/releases/download/v${PV}/slackdump_Linux_x86_64.tar.gz -> ${P}-slackdump_Linux_x86_64.tar.gz  )  
   arm64? (  https://github.com/rusq/slackdump/releases/download/v${PV}/slackdump_Linux_arm64.tar.gz -> ${P}-slackdump_Linux_arm64.tar.gz  )  


### PR DESCRIPTION
- Add 'debug' USE flag to app-misc/kjules/metadata.xml
- Add HOMEPAGE to app-misc/maid-appimage/maid-appimage-1.3.1.ebuild
- Add HOMEPAGE to net-im/slackdump-bin/slackdump-bin-4.4.2.ebuild
- Record missing generator HOMEPAGE feature in gap.md

---
*PR created automatically by Jules for task [17756972278208533210](https://jules.google.com/task/17756972278208533210) started by @arran4*