### PR TITLE
Fix hardcoded superfile binary extraction paths

### DIFF
--- a/.github/workflows/app-misc-superfile-bin-update.yaml
+++ b/.github/workflows/app-misc-superfile-bin-update.yaml
@@ -28,9 +28,9 @@ env:
   keywords: ~amd64 ~arm64
   workflow_filename: app-misc-superfile-bin-update.yaml
   spf_binary_installed_name: 'spf'
-  spf_binary_archived_name_amd64: './dist/superfile-linux-v1.1.4-amd64/spf'
+  spf_binary_archived_name_amd64: './dist/superfile-linux-${tag}-amd64/spf'
   spf_release_name_amd64: 'superfile-linux-${tag}-amd64.tar.gz'
-  spf_binary_archived_name_arm64: './dist/superfile-linux-v1.1.4-arm64/spf'
+  spf_binary_archived_name_arm64: './dist/superfile-linux-${tag}-arm64/spf'
   spf_release_name_arm64: 'superfile-linux-${tag}-arm64.tar.gz'
 
 jobs:

--- a/app-misc/superfile-bin/superfile-bin-1.6.0.ebuild
+++ b/app-misc/superfile-bin/superfile-bin-1.6.0.ebuild
@@ -29,9 +29,9 @@ src_unpack() {
 src_install() {
   exeinto /opt/bin
   if use amd64; then
-    newexe "./dist/superfile-linux-v1.1.4-amd64/spf" "spf" || die "Failed to install Binary"
+    newexe "./dist/superfile-linux-v${PV}-amd64/spf" "spf" || die "Failed to install Binary"
   fi
   if use arm64; then
-    newexe "./dist/superfile-linux-v1.1.4-arm64/spf" "spf" || die "Failed to install Binary"
+    newexe "./dist/superfile-linux-v${PV}-arm64/spf" "spf" || die "Failed to install Binary"
   fi
 }

--- a/app-misc/superfile-bin/superfile-bin-1.6.0_rc.ebuild
+++ b/app-misc/superfile-bin/superfile-bin-1.6.0_rc.ebuild
@@ -29,9 +29,9 @@ src_unpack() {
 src_install() {
   exeinto /opt/bin
   if use amd64; then
-    newexe "./dist/superfile-linux-v1.1.4-amd64/spf" "spf" || die "Failed to install Binary"
+    newexe "./dist/superfile-linux-v${PV}-amd64/spf" "spf" || die "Failed to install Binary"
   fi
   if use arm64; then
-    newexe "./dist/superfile-linux-v1.1.4-arm64/spf" "spf" || die "Failed to install Binary"
+    newexe "./dist/superfile-linux-v${PV}-arm64/spf" "spf" || die "Failed to install Binary"
   fi
 }

--- a/current.config
+++ b/current.config
@@ -163,8 +163,8 @@ Homepage https://superfile.netlify.app
 License MIT License
 Workaround Semantic Version Prerelease Hack 1
 ProgramName spf
-Binary amd64=>superfile-linux-${TAG}-amd64.tar.gz > ./dist/superfile-linux-v1.1.4-amd64/spf > spf
-Binary arm64=>superfile-linux-${TAG}-arm64.tar.gz > ./dist/superfile-linux-v1.1.4-arm64/spf > spf
+Binary amd64=>superfile-linux-${TAG}-amd64.tar.gz > ./dist/superfile-linux-${TAG}-amd64/spf > spf
+Binary arm64=>superfile-linux-${TAG}-arm64.tar.gz > ./dist/superfile-linux-${TAG}-arm64/spf > spf
 
 Type Github Binary Release
 GithubProjectUrl https://github.com/CloudCannon/pagefind


### PR DESCRIPTION
This fixes an issue where installing superfile-bin fails because the ebuild expects the extracted path to contain a hardcoded older version (v1.1.4) instead of the version corresponding to the release.
I replaced the hardcoded `v1.1.4` directory in the `superfile-bin` binary extraction paths with `${TAG}` in `current.config`, `${tag}` in the github action workflow, and `v${PV}` in the ebuilds.

---
*PR created automatically by Jules for task [16737304998435493378](https://jules.google.com/task/16737304998435493378) started by @arran4*