### PR TITLE
Update ebuild generator workflows to v0.1.28 and doc issues

### DIFF
--- a/.github/workflows/app-admin-arrans-overlay-workflow-builder-bin-update.yaml
+++ b/.github/workflows/app-admin-arrans-overlay-workflow-builder-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: app-admin/arrans-overlay-workflow-builder-bin update
 
@@ -38,37 +38,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">arran4/arrans_overlay_workflow_builder</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:arran4/arrans_overlay_workflow_builder" --use-add "amd64:Enable amd64" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -93,8 +79,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -103,25 +89,20 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/arrans_overlay_workflow_builder_\${PV}_linux_amd64.tar.gz -> \${P}-arrans_overlay_workflow_builder_\${PV}_linux_amd64.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/arrans_overlay_workflow_builder_\${PV}_linux_amd64.tar.gz -> \${P}-arrans_overlay_workflow_builder_\${PV}_linux_amd64.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="unknown"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
                 echo -n ' doc'
-                echo -n ''
+                echo -n ' amd64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -141,18 +122,44 @@ jobs:
                 echo '    newdoc "readme.md" "readme.md" || die "Failed to install document readme.md"'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/arrans_overlay_workflow_builder_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-arrans_overlay_workflow_builder_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/arrans_overlay_workflow_builder_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-arrans_overlay_workflow_builder_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/app-admin-chezmoi-bin-update.yaml
+++ b/.github/workflows/app-admin-chezmoi-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: app-admin/chezmoi-bin update
 
@@ -62,43 +62,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <use>
-              <flag name="android">Install android binary</flag>
-              <flag name="glibc">Install glibc binary</flag>
-              <flag name="le">Install le binary</flag>
-              <flag name="loong64">Install loong64 binary</flag>
-            </use>
-            <upstream>
-              <remote-id type="github">twpayne/chezmoi</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:twpayne/chezmoi" --use-add "amd64:Enable amd64" --use-add "android:Install android binary" --use-add "arm:Enable arm" --use-add "arm64:Enable arm64" --use-add "glibc:Install glibc binary" --use-add "le:Install le binary" --use-add "loong64:Install loong64 binary" --use-add "ppc64:Enable ppc64" --use-add "riscv:Enable riscv" --use-add "s390:Enable s390" --use-add "x86:Enable x86" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -123,8 +103,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -133,26 +113,24 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? ( glibc? ( !loong64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/chezmoi_\${PV}_linux-glibc_amd64.tar.gz -> \${P}-chezmoi_\${PV}_linux-glibc_amd64.tar.gz  )  )  )  "
-                echo "  amd64? ( !glibc? ( !loong64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/chezmoi_\${PV}_linux-musl_amd64.tar.gz -> \${P}-chezmoi_\${PV}_linux-musl_amd64.tar.gz  )  )  )  "
-                echo "  amd64? ( loong64? ( !glibc? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/chezmoi_\${PV}_linux_loong64.tar.gz -> \${P}-chezmoi_\${PV}_linux_loong64.tar.gz  )  )  )  "
-                echo "  arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/chezmoi_\${PV}_linux_armv6.tar.gz -> \${P}-chezmoi_\${PV}_linux_armv6.tar.gz  )  "
-                echo "  arm64? ( android? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/chezmoi_\${PV}_android_arm64.tar.gz -> \${P}-chezmoi_\${PV}_android_arm64.tar.gz  )  )  "
-                echo "  arm64? ( !android? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/chezmoi_\${PV}_linux_arm64.tar.gz -> \${P}-chezmoi_\${PV}_linux_arm64.tar.gz  )  )  "
-                echo "  ppc64? ( !le? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/chezmoi_\${PV}_linux_ppc64.tar.gz -> \${P}-chezmoi_\${PV}_linux_ppc64.tar.gz  )  )  "
-                echo "  ppc64? ( le? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/chezmoi_\${PV}_linux_ppc64le.tar.gz -> \${P}-chezmoi_\${PV}_linux_ppc64le.tar.gz  )  )  "
-                echo "  riscv? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/chezmoi_\${PV}_linux_riscv64.tar.gz -> \${P}-chezmoi_\${PV}_linux_riscv64.tar.gz  )  "
-                echo "  s390? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/chezmoi_\${PV}_linux_s390x.tar.gz -> \${P}-chezmoi_\${PV}_linux_s390x.tar.gz  )  "
-                echo "  x86? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/chezmoi_\${PV}_linux_i386.tar.gz -> \${P}-chezmoi_\${PV}_linux_i386.tar.gz  )  "
+                echo "	amd64? ( glibc? ( !loong64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/chezmoi_\${PV}_linux-glibc_amd64.tar.gz -> \${P}-chezmoi_\${PV}_linux-glibc_amd64.tar.gz  )  )  )  "
+                echo "	amd64? ( !glibc? ( !loong64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/chezmoi_\${PV}_linux-musl_amd64.tar.gz -> \${P}-chezmoi_\${PV}_linux-musl_amd64.tar.gz  )  )  )  "
+                echo "	amd64? ( loong64? ( !glibc? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/chezmoi_\${PV}_linux_loong64.tar.gz -> \${P}-chezmoi_\${PV}_linux_loong64.tar.gz  )  )  )  "
+                echo "	arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/chezmoi_\${PV}_linux_armv6.tar.gz -> \${P}-chezmoi_\${PV}_linux_armv6.tar.gz  )  "
+                echo "	arm64? ( android? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/chezmoi_\${PV}_android_arm64.tar.gz -> \${P}-chezmoi_\${PV}_android_arm64.tar.gz  )  )  "
+                echo "	arm64? ( !android? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/chezmoi_\${PV}_linux_arm64.tar.gz -> \${P}-chezmoi_\${PV}_linux_arm64.tar.gz  )  )  "
+                echo "	ppc64? ( !le? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/chezmoi_\${PV}_linux_ppc64.tar.gz -> \${P}-chezmoi_\${PV}_linux_ppc64.tar.gz  )  )  "
+                echo "	ppc64? ( le? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/chezmoi_\${PV}_linux_ppc64le.tar.gz -> \${P}-chezmoi_\${PV}_linux_ppc64le.tar.gz  )  )  "
+                echo "	riscv? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/chezmoi_\${PV}_linux_riscv64.tar.gz -> \${P}-chezmoi_\${PV}_linux_riscv64.tar.gz  )  "
+                echo "	s390? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/chezmoi_\${PV}_linux_s390x.tar.gz -> \${P}-chezmoi_\${PV}_linux_s390x.tar.gz  )  "
+                echo "	x86? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/chezmoi_\${PV}_linux_i386.tar.gz -> \${P}-chezmoi_\${PV}_linux_i386.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="MIT License"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
                 echo -n ' android glibc le loong64'
-                echo -n ''
-                echo -n ''
-                echo -n ''
+                echo -n ' amd64 android arm arm64 glibc le loong64 ppc64 riscv s390 x86'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
@@ -160,7 +138,6 @@ jobs:
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
                 echo -n ''
                 echo '"'
                 echo ''
@@ -238,28 +215,54 @@ jobs:
                 echo '    newexe "${{ env.loong64_binary_archived_name_amd64 }}" "${{ env.loong64_binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/chezmoi_${version}_linux-glibc_amd64.tar.gz" "${{ env.epn }}-${version}-chezmoi_${version}_linux-glibc_amd64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/chezmoi_${version}_linux-musl_amd64.tar.gz" "${{ env.epn }}-${version}-chezmoi_${version}_linux-musl_amd64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/chezmoi_${version}_linux_loong64.tar.gz" "${{ env.epn }}-${version}-chezmoi_${version}_linux_loong64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/chezmoi_${version}_linux_armv6.tar.gz" "${{ env.epn }}-${version}-chezmoi_${version}_linux_armv6.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/chezmoi_${version}_android_arm64.tar.gz" "${{ env.epn }}-${version}-chezmoi_${version}_android_arm64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/chezmoi_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-chezmoi_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/chezmoi_${version}_linux_ppc64.tar.gz" "${{ env.epn }}-${version}-chezmoi_${version}_linux_ppc64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/chezmoi_${version}_linux_ppc64le.tar.gz" "${{ env.epn }}-${version}-chezmoi_${version}_linux_ppc64le.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/chezmoi_${version}_linux_riscv64.tar.gz" "${{ env.epn }}-${version}-chezmoi_${version}_linux_riscv64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/chezmoi_${version}_linux_s390x.tar.gz" "${{ env.epn }}-${version}-chezmoi_${version}_linux_s390x.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/chezmoi_${version}_linux_i386.tar.gz" "${{ env.epn }}-${version}-chezmoi_${version}_linux_i386.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/chezmoi_${version}_linux-glibc_amd64.tar.gz" "${{ env.epn }}-${version}-chezmoi_${version}_linux-glibc_amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/chezmoi_${version}_linux-musl_amd64.tar.gz" "${{ env.epn }}-${version}-chezmoi_${version}_linux-musl_amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/chezmoi_${version}_linux_loong64.tar.gz" "${{ env.epn }}-${version}-chezmoi_${version}_linux_loong64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/chezmoi_${version}_linux_armv6.tar.gz" "${{ env.epn }}-${version}-chezmoi_${version}_linux_armv6.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/chezmoi_${version}_android_arm64.tar.gz" "${{ env.epn }}-${version}-chezmoi_${version}_android_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/chezmoi_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-chezmoi_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/chezmoi_${version}_linux_ppc64.tar.gz" "${{ env.epn }}-${version}-chezmoi_${version}_linux_ppc64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/chezmoi_${version}_linux_ppc64le.tar.gz" "${{ env.epn }}-${version}-chezmoi_${version}_linux_ppc64le.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/chezmoi_${version}_linux_riscv64.tar.gz" "${{ env.epn }}-${version}-chezmoi_${version}_linux_riscv64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/chezmoi_${version}_linux_s390x.tar.gz" "${{ env.epn }}-${version}-chezmoi_${version}_linux_s390x.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/chezmoi_${version}_linux_i386.tar.gz" "${{ env.epn }}-${version}-chezmoi_${version}_linux_i386.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/app-admin-ejson-bin-update.yaml
+++ b/.github/workflows/app-admin-ejson-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: app-admin/ejson-bin update
 
@@ -40,37 +40,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">Shopify/ejson</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:Shopify/ejson" --use-add "amd64:Enable amd64" --use-add "arm64:Enable arm64" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -95,8 +81,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -105,26 +91,21 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/ejson_\${PV}_linux_amd64.tar.gz -> \${P}-ejson_\${PV}_linux_amd64.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/ejson_\${PV}_linux_arm64.tar.gz -> \${P}-ejson_\${PV}_linux_arm64.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/ejson_\${PV}_linux_amd64.tar.gz -> \${P}-ejson_\${PV}_linux_amd64.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/ejson_\${PV}_linux_arm64.tar.gz -> \${P}-ejson_\${PV}_linux_arm64.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="MIT License"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
                 echo -n ' doc'
-                echo -n ''
+                echo -n ' amd64 arm64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -152,19 +133,45 @@ jobs:
                 echo '    newdoc "README.md" "README.md" || die "Failed to install document README.md"'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/ejson_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-ejson_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/ejson_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-ejson_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/ejson_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-ejson_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/ejson_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-ejson_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/app-admin-g2-bin-update.yaml
+++ b/.github/workflows/app-admin-g2-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: app-admin/g2-bin update
 
@@ -42,37 +42,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">arran4/g2</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:arran4/g2" --use-add "amd64:Enable amd64" --use-add "arm:Enable arm" --use-add "arm64:Enable arm64" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -97,8 +83,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -107,27 +93,21 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/g2_\${PV}_linux_amd64.tar.gz -> \${P}-g2_\${PV}_linux_amd64.tar.gz  )  "
-                echo "  arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/g2_\${PV}_linux_armv6.tar.gz -> \${P}-g2_\${PV}_linux_armv6.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/g2_\${PV}_linux_arm64.tar.gz -> \${P}-g2_\${PV}_linux_arm64.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/g2_\${PV}_linux_amd64.tar.gz -> \${P}-g2_\${PV}_linux_amd64.tar.gz  )  "
+                echo "	arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/g2_\${PV}_linux_armv6.tar.gz -> \${P}-g2_\${PV}_linux_armv6.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/g2_\${PV}_linux_arm64.tar.gz -> \${P}-g2_\${PV}_linux_arm64.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="unknown"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
-                echo -n ''
-                echo -n ''
+                echo -n ' amd64 arm arm64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -156,20 +136,46 @@ jobs:
                 echo '    newexe "${{ env.binary_archived_name_arm64 }}" "${{ env.binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/g2_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-g2_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/g2_${version}_linux_armv6.tar.gz" "${{ env.epn }}-${version}-g2_${version}_linux_armv6.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/g2_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-g2_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/g2_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-g2_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/g2_${version}_linux_armv6.tar.gz" "${{ env.epn }}-${version}-g2_${version}_linux_armv6.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/g2_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-g2_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/app-misc-anytype-to-linkwarden-bin-update.yaml
+++ b/.github/workflows/app-misc-anytype-to-linkwarden-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: app-misc/anytype-to-linkwarden-bin update
 
@@ -40,37 +40,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">arran4/anytype-to-linkwarden</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:arran4/anytype-to-linkwarden" --use-add "amd64:Enable amd64" --use-add "arm64:Enable arm64" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -95,8 +81,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -105,26 +91,21 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/anytype-to-linkwarden_\${PV}_linux_amd64.tar.gz -> \${P}-anytype-to-linkwarden_\${PV}_linux_amd64.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/anytype-to-linkwarden_\${PV}_linux_arm64.tar.gz -> \${P}-anytype-to-linkwarden_\${PV}_linux_arm64.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/anytype-to-linkwarden_\${PV}_linux_amd64.tar.gz -> \${P}-anytype-to-linkwarden_\${PV}_linux_amd64.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/anytype-to-linkwarden_\${PV}_linux_arm64.tar.gz -> \${P}-anytype-to-linkwarden_\${PV}_linux_arm64.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="unknown"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
                 echo -n ' doc'
-                echo -n ''
+                echo -n ' amd64 arm64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -156,19 +137,45 @@ jobs:
                 echo '    fi'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/anytype-to-linkwarden_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-anytype-to-linkwarden_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/anytype-to-linkwarden_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-anytype-to-linkwarden_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/anytype-to-linkwarden_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-anytype-to-linkwarden_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/anytype-to-linkwarden_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-anytype-to-linkwarden_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/app-misc-chatbox-appimage-update.yaml
+++ b/.github/workflows/app-misc-chatbox-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github AppImage Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github AppImage Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: app-misc/chatbox-appimage update
 
@@ -39,37 +39,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">Bin-Huang/chatbox</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:Bin-Huang/chatbox" "$metadata_file"
           declare -A releaseTypes=()
-            tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -90,8 +76,8 @@ jobs:
                 echo "Already have a newier ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -99,12 +85,12 @@ jobs:
                 echo 'EAPI=8'
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="GNU General Public License v3.0"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo 'IUSE=""'
                 echo 'DEPEND=""'
-                echo 'RDEPEND="sys-libs/glibc sys-libs/glibc sys-libs/zlib sys-libs/zlib "'
+                echo 'RDEPEND="sys-fs/fuse:0 sys-fs/fuse:0 sys-libs/glibc sys-libs/zlib"'
                 echo 'S="${WORKDIR}"'
                 echo 'RESTRICT="strip"'
                 echo ''
@@ -150,19 +136,46 @@ jobs:
                 echo "  xdg_desktop_database_update"
                 echo "}"
                 echo ""
-              } > $ebuild_file
 
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/Chatbox.CE-${version}-arm64.AppImage" "${{ env.epn }}-${version}-Chatbox.CE-${version}-arm64.AppImage" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/Chatbox.CE-${version}-x86_64.AppImage" "${{ env.epn }}-${version}-Chatbox.CE-${version}-x86_64.AppImage" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/Chatbox.CE-${version}-arm64.AppImage" "${{ env.epn }}-${version}-Chatbox.CE-${version}-arm64.AppImage" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/Chatbox.CE-${version}-x86_64.AppImage" "${{ env.epn }}-${version}-Chatbox.CE-${version}-x86_64.AppImage" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/app-misc-dua-cli-bin-update.yaml
+++ b/.github/workflows/app-misc-dua-cli-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: app-misc/dua-cli-bin update
 
@@ -42,37 +42,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">Byron/dua-cli</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:Byron/dua-cli" --use-add "amd64:Enable amd64" --use-add "arm:Enable arm" --use-add "arm64:Enable arm64" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -97,8 +83,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -107,27 +93,23 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/dua-${tag}-x86_64-unknown-linux-musl.tar.gz -> \${P}-dua-${tag}-x86_64-unknown-linux-musl.tar.gz  )  "
-                echo "  arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/dua-${tag}-arm-unknown-linux-gnueabihf.tar.gz -> \${P}-dua-${tag}-arm-unknown-linux-gnueabihf.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/dua-${tag}-aarch64-unknown-linux-musl.tar.gz -> \${P}-dua-${tag}-aarch64-unknown-linux-musl.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/dua-${tag}-x86_64-unknown-linux-musl.tar.gz -> \${P}-dua-${tag}-x86_64-unknown-linux-musl.tar.gz  )  "
+                echo "	arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/dua-${tag}-arm-unknown-linux-gnueabihf.tar.gz -> \${P}-dua-${tag}-arm-unknown-linux-gnueabihf.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/dua-${tag}-aarch64-unknown-linux-musl.tar.gz -> \${P}-dua-${tag}-aarch64-unknown-linux-musl.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="MIT License"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
                 echo -n ' doc'
-                echo -n ''
+                echo -n ' amd64 arm arm64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
                 echo -n 'sys-devel/gcc '
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -173,20 +155,46 @@ jobs:
                 echo '    fi'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/dua-${tag}-x86_64-unknown-linux-musl.tar.gz" "${{ env.epn }}-${version}-dua-${tag}-x86_64-unknown-linux-musl.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/dua-${tag}-arm-unknown-linux-gnueabihf.tar.gz" "${{ env.epn }}-${version}-dua-${tag}-arm-unknown-linux-gnueabihf.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/dua-${tag}-aarch64-unknown-linux-musl.tar.gz" "${{ env.epn }}-${version}-dua-${tag}-aarch64-unknown-linux-musl.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/dua-${tag}-x86_64-unknown-linux-musl.tar.gz" "${{ env.epn }}-${version}-dua-${tag}-x86_64-unknown-linux-musl.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/dua-${tag}-arm-unknown-linux-gnueabihf.tar.gz" "${{ env.epn }}-${version}-dua-${tag}-arm-unknown-linux-gnueabihf.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/dua-${tag}-aarch64-unknown-linux-musl.tar.gz" "${{ env.epn }}-${version}-dua-${tag}-aarch64-unknown-linux-musl.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/app-misc-flutter-google-datastore-appimage-update.yaml
+++ b/.github/workflows/app-misc-flutter-google-datastore-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github AppImage Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github AppImage Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: app-misc/flutter-google-datastore-appimage update
 
@@ -38,37 +38,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">arran4/flutter_google_datastore</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:arran4/flutter_google_datastore" "$metadata_file"
           declare -A releaseTypes=()
-            tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -90,8 +76,8 @@ jobs:
                 echo "Already have a newier ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -99,12 +85,12 @@ jobs:
                 echo 'EAPI=8'
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="MIT License"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo 'IUSE=""'
                 echo 'DEPEND=""'
-                echo 'RDEPEND="sys-libs/glibc sys-libs/zlib "'
+                echo 'RDEPEND="sys-fs/fuse:0 sys-fs/fuse:0 sys-libs/glibc sys-libs/zlib"'
                 echo 'S="${WORKDIR}"'
                 echo 'RESTRICT="strip"'
                 echo ''
@@ -146,18 +132,45 @@ jobs:
                 echo "  xdg_desktop_database_update"
                 echo "}"
                 echo ""
-              } > $ebuild_file
 
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/flutter_google_datastore-${originalVersion}-linux.AppImage" "${{ env.epn }}-${version}-flutter_google_datastore-${version}-linux.AppImage" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/flutter_google_datastore-${originalVersion}-linux.AppImage" "${{ env.epn }}-${version}-flutter_google_datastore-${version}-linux.AppImage" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/app-misc-flutter-jules-bin-update.yaml
+++ b/.github/workflows/app-misc-flutter-jules-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: app-misc/flutter-jules-bin update
 
@@ -38,37 +38,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">arran4/flutter_jules</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:arran4/flutter_jules" --use-add "amd64:Enable amd64" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -93,8 +79,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -103,25 +89,20 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/flutter_jules-linux.tar.gz -> \${P}-flutter_jules-linux.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/flutter_jules-linux.tar.gz -> \${P}-flutter_jules-linux.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="unknown"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
-                echo -n ''
-                echo -n ''
+                echo -n ' amd64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
                 echo -n 'media-libs/libglvnd sys-devel/gcc sys-libs/zlib x11-libs/gtk+ x11-libs/libX11 '
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -138,18 +119,44 @@ jobs:
                 echo '    newexe "${{ env.jules_client_binary_archived_name_amd64 }}" "${{ env.jules_client_binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/flutter_jules-linux.tar.gz" "${{ env.epn }}-${version}-flutter_jules-linux.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/flutter_jules-linux.tar.gz" "${{ env.epn }}-${version}-flutter_jules-linux.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/app-misc-fq-bin-update.yaml
+++ b/.github/workflows/app-misc-fq-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: app-misc/fq-bin update
 
@@ -40,37 +40,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">wader/fq</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:wader/fq" --use-add "amd64:Enable amd64" --use-add "arm64:Enable arm64" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -95,8 +81,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -105,26 +91,20 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/fq_\${PV}_linux_amd64.tar.gz -> \${P}-fq_\${PV}_linux_amd64.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/fq_\${PV}_linux_arm64.tar.gz -> \${P}-fq_\${PV}_linux_arm64.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/fq_\${PV}_linux_amd64.tar.gz -> \${P}-fq_\${PV}_linux_amd64.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/fq_\${PV}_linux_arm64.tar.gz -> \${P}-fq_\${PV}_linux_arm64.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="Other"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
-                echo -n ''
-                echo -n ''
+                echo -n ' amd64 arm64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -147,19 +127,45 @@ jobs:
                 echo '    newexe "${{ env.fq_binary_archived_name_arm64 }}" "${{ env.fq_binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/fq_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-fq_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/fq_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-fq_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/fq_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-fq_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/fq_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-fq_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/app-misc-gocdm-bin-update.yaml
+++ b/.github/workflows/app-misc-gocdm-bin-update.yaml
@@ -58,19 +58,9 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">arran4/gocdm</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:${{ env.github_owner }}/${{ env.github_repo }}" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -95,8 +85,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -175,19 +165,35 @@ jobs:
                 echo '  einfo "Note: The binary release might not have PAM support compiled in."'
                 echo '  einfo "See https://github.com/arran4/gocdm for more details."'
                 echo '}'
-              } > $ebuild_file
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
 
               # Manifest generation
 
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/gocdm_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-gocdm_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/gocdm_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-gocdm_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/gocdm_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-gocdm_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/gocdm_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-gocdm_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/app-misc-maid-appimage-update.yaml
+++ b/.github/workflows/app-misc-maid-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github AppImage Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github AppImage Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: app-misc/maid-appimage update
 
@@ -38,37 +38,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">Mobile-Artificial-Intelligence/maid</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:Mobile-Artificial-Intelligence/maid" "$metadata_file"
           declare -A releaseTypes=()
-            tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag}"
@@ -85,8 +71,8 @@ jobs:
                 echo "Already have a newier ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -94,12 +80,12 @@ jobs:
                 echo 'EAPI=8'
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="MIT License"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo 'IUSE=""'
                 echo 'DEPEND=""'
-                echo 'RDEPEND="sys-libs/glibc sys-libs/zlib "'
+                echo 'RDEPEND="sys-fs/fuse:0 sys-fs/fuse:0 sys-libs/glibc sys-libs/zlib"'
                 echo 'S="${WORKDIR}"'
                 echo 'RESTRICT="strip"'
                 echo ''
@@ -136,18 +122,45 @@ jobs:
                 echo "  xdg_desktop_database_update"
                 echo "}"
                 echo ""
-              } > $ebuild_file
 
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/maid.AppImage" "${{ env.epn }}-${version}-maid.AppImage" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/maid.AppImage" "${{ env.epn }}-${version}-maid.AppImage" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/app-misc-mvcommon-bin-update.yaml
+++ b/.github/workflows/app-misc-mvcommon-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: app-misc/mvcommon-bin update
 
@@ -40,37 +40,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">arran4/mvcommon</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:arran4/mvcommon" --use-add "amd64:Enable amd64" --use-add "arm64:Enable arm64" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -95,8 +81,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -105,26 +91,21 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/mvcommon_\${PV}_linux_amd64.tar.gz -> \${P}-mvcommon_\${PV}_linux_amd64.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/mvcommon_\${PV}_linux_arm64.tar.gz -> \${P}-mvcommon_\${PV}_linux_arm64.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/mvcommon_\${PV}_linux_amd64.tar.gz -> \${P}-mvcommon_\${PV}_linux_amd64.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/mvcommon_\${PV}_linux_arm64.tar.gz -> \${P}-mvcommon_\${PV}_linux_arm64.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="GNU General Public License v3.0"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
                 echo -n ' doc'
-                echo -n ''
+                echo -n ' amd64 arm64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -151,19 +132,45 @@ jobs:
                 echo '    newdoc "readme.md" "readme.md" || die "Failed to install document readme.md"'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/mvcommon_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-mvcommon_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/mvcommon_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-mvcommon_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/mvcommon_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-mvcommon_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/mvcommon_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-mvcommon_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/app-misc-picocrypt-bin-update.yaml
+++ b/.github/workflows/app-misc-picocrypt-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: app-misc/picocrypt-bin update
 
@@ -37,37 +37,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">Picocrypt/Picocrypt</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:Picocrypt/Picocrypt" --use-add "amd64:Enable amd64" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag}"
@@ -88,8 +74,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -98,25 +84,20 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/\${PV}/Picocrypt -> \${P}-Picocrypt  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/\${PV}/Picocrypt -> \${P}-Picocrypt  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="GNU General Public License v3.0"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
-                echo -n ''
-                echo -n ''
+                echo -n ' amd64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
                 echo -n 'media-libs/libglvnd sys-devel/gcc x11-libs/gtk+ x11-libs/libX11 '
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -129,18 +110,44 @@ jobs:
                 echo '    newexe "${DISTDIR}/${P}-${{ env.Picocrypt_release_name_amd64 }}" "${{ env.Picocrypt_binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/Picocrypt" "${{ env.epn }}-${version}-Picocrypt" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/Picocrypt" "${{ env.epn }}-${version}-Picocrypt" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/app-misc-rntocase-bin-update.yaml
+++ b/.github/workflows/app-misc-rntocase-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: app-misc/rntocase-bin update
 
@@ -106,37 +106,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">arran4/rntocase</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:arran4/rntocase" --use-add "amd64:Enable amd64" --use-add "arm64:Enable arm64" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -161,8 +147,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -171,26 +157,21 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/rntocase_\${PV}_linux_amd64.tar.gz -> \${P}-rntocase_\${PV}_linux_amd64.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/rntocase_\${PV}_linux_arm64.tar.gz -> \${P}-rntocase_\${PV}_linux_arm64.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/rntocase_\${PV}_linux_amd64.tar.gz -> \${P}-rntocase_\${PV}_linux_amd64.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/rntocase_\${PV}_linux_arm64.tar.gz -> \${P}-rntocase_\${PV}_linux_arm64.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="GNU General Public License v3.0"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
                 echo -n ' doc'
-                echo -n ''
+                echo -n ' amd64 arm64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -297,19 +278,45 @@ jobs:
                 echo '    fi'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/rntocase_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-rntocase_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/rntocase_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-rntocase_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/rntocase_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-rntocase_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/rntocase_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-rntocase_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/app-misc-shineyshot-bin-update.yaml
+++ b/.github/workflows/app-misc-shineyshot-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: app-misc/shineyshot-bin update
 
@@ -44,37 +44,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">arran4/shineyshot</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:arran4/shineyshot" --use-add "amd64:Enable amd64" --use-add "arm:Enable arm" --use-add "arm64:Enable arm64" --use-add "x86:Enable x86" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -99,8 +85,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -109,28 +95,23 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/shineyshot_\${PV}_Linux_x86_64.tar.gz -> \${P}-shineyshot_\${PV}_Linux_x86_64.tar.gz  )  "
-                echo "  arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/shineyshot_\${PV}_Linux_armv7.tar.gz -> \${P}-shineyshot_\${PV}_Linux_armv7.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/shineyshot_\${PV}_Linux_arm64.tar.gz -> \${P}-shineyshot_\${PV}_Linux_arm64.tar.gz  )  "
-                echo "  x86? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/shineyshot_\${PV}_Linux_i386.tar.gz -> \${P}-shineyshot_\${PV}_Linux_i386.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/shineyshot_\${PV}_Linux_x86_64.tar.gz -> \${P}-shineyshot_\${PV}_Linux_x86_64.tar.gz  )  "
+                echo "	arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/shineyshot_\${PV}_Linux_armv7.tar.gz -> \${P}-shineyshot_\${PV}_Linux_armv7.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/shineyshot_\${PV}_Linux_arm64.tar.gz -> \${P}-shineyshot_\${PV}_Linux_arm64.tar.gz  )  "
+                echo "	x86? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/shineyshot_\${PV}_Linux_i386.tar.gz -> \${P}-shineyshot_\${PV}_Linux_i386.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="GNU Affero General Public License v3.0"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
                 echo -n ' doc'
-                echo -n ''
+                echo -n ' amd64 arm arm64 x86'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -180,21 +161,47 @@ jobs:
                 echo '    fi'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/shineyshot_${version}_Linux_x86_64.tar.gz" "${{ env.epn }}-${version}-shineyshot_${version}_Linux_x86_64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/shineyshot_${version}_Linux_armv7.tar.gz" "${{ env.epn }}-${version}-shineyshot_${version}_Linux_armv7.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/shineyshot_${version}_Linux_arm64.tar.gz" "${{ env.epn }}-${version}-shineyshot_${version}_Linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/shineyshot_${version}_Linux_i386.tar.gz" "${{ env.epn }}-${version}-shineyshot_${version}_Linux_i386.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/shineyshot_${version}_Linux_x86_64.tar.gz" "${{ env.epn }}-${version}-shineyshot_${version}_Linux_x86_64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/shineyshot_${version}_Linux_armv7.tar.gz" "${{ env.epn }}-${version}-shineyshot_${version}_Linux_armv7.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/shineyshot_${version}_Linux_arm64.tar.gz" "${{ env.epn }}-${version}-shineyshot_${version}_Linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/shineyshot_${version}_Linux_i386.tar.gz" "${{ env.epn }}-${version}-shineyshot_${version}_Linux_i386.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/app-misc-superfile-bin-update.yaml
+++ b/.github/workflows/app-misc-superfile-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: app-misc/superfile-bin update
 
@@ -28,9 +28,9 @@ env:
   keywords: ~amd64 ~arm64
   workflow_filename: app-misc-superfile-bin-update.yaml
   spf_binary_installed_name: 'spf'
-  spf_binary_archived_name_amd64: './dist/superfile-linux-${tag}-amd64/spf'
+  spf_binary_archived_name_amd64: './dist/superfile-linux-${TAG}-amd64/spf'
   spf_release_name_amd64: 'superfile-linux-${tag}-amd64.tar.gz'
-  spf_binary_archived_name_arm64: './dist/superfile-linux-${tag}-arm64/spf'
+  spf_binary_archived_name_arm64: './dist/superfile-linux-${TAG}-arm64/spf'
   spf_release_name_arm64: 'superfile-linux-${tag}-arm64.tar.gz'
 
 jobs:
@@ -40,37 +40,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">yorukot/superfile</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:yorukot/superfile" --use-add "amd64:Enable amd64" --use-add "arm64:Enable arm64" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -96,8 +82,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -106,26 +92,20 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/superfile-linux-${tag}-amd64.tar.gz -> \${P}-superfile-linux-${tag}-amd64.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/superfile-linux-${tag}-arm64.tar.gz -> \${P}-superfile-linux-${tag}-arm64.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/superfile-linux-${tag}-amd64.tar.gz -> \${P}-superfile-linux-${tag}-amd64.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/superfile-linux-${tag}-arm64.tar.gz -> \${P}-superfile-linux-${tag}-arm64.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="MIT License"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
-                echo -n ''
-                echo -n ''
+                echo -n ' amd64 arm64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -148,19 +128,45 @@ jobs:
                 echo '    newexe "${{ env.spf_binary_archived_name_arm64 }}" "${{ env.spf_binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/superfile-linux-${tag}-amd64.tar.gz" "${{ env.epn }}-${version}-superfile-linux-${tag}-amd64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/superfile-linux-${tag}-arm64.tar.gz" "${{ env.epn }}-${version}-superfile-linux-${tag}-arm64.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/superfile-linux-${tag}-amd64.tar.gz" "${{ env.epn }}-${version}-superfile-linux-${tag}-amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/superfile-linux-${tag}-arm64.tar.gz" "${{ env.epn }}-${version}-superfile-linux-${tag}-arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/app-text-md2png-bin-update.yaml
+++ b/.github/workflows/app-text-md2png-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: app-text/md2png-bin update
 
@@ -42,37 +42,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">arran4/md2png</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:arran4/md2png" --use-add "amd64:Enable amd64" --use-add "arm:Enable arm" --use-add "arm64:Enable arm64" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -97,8 +83,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -107,27 +93,21 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/md2png_\${PV}_Linux_x86_64.tar.gz -> \${P}-md2png_\${PV}_Linux_x86_64.tar.gz  )  "
-                echo "  arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/md2png_\${PV}_Linux_armv7.tar.gz -> \${P}-md2png_\${PV}_Linux_armv7.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/md2png_\${PV}_Linux_arm64.tar.gz -> \${P}-md2png_\${PV}_Linux_arm64.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/md2png_\${PV}_Linux_x86_64.tar.gz -> \${P}-md2png_\${PV}_Linux_x86_64.tar.gz  )  "
+                echo "	arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/md2png_\${PV}_Linux_armv7.tar.gz -> \${P}-md2png_\${PV}_Linux_armv7.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/md2png_\${PV}_Linux_arm64.tar.gz -> \${P}-md2png_\${PV}_Linux_arm64.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="MIT License"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
-                echo -n ''
-                echo -n ''
+                echo -n ' amd64 arm arm64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -156,20 +136,46 @@ jobs:
                 echo '    newexe "${{ env.md2png_binary_archived_name_arm64 }}" "${{ env.md2png_binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/md2png_${version}_Linux_x86_64.tar.gz" "${{ env.epn }}-${version}-md2png_${version}_Linux_x86_64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/md2png_${version}_Linux_armv7.tar.gz" "${{ env.epn }}-${version}-md2png_${version}_Linux_armv7.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/md2png_${version}_Linux_arm64.tar.gz" "${{ env.epn }}-${version}-md2png_${version}_Linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/md2png_${version}_Linux_x86_64.tar.gz" "${{ env.epn }}-${version}-md2png_${version}_Linux_x86_64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/md2png_${version}_Linux_armv7.tar.gz" "${{ env.epn }}-${version}-md2png_${version}_Linux_armv7.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/md2png_${version}_Linux_arm64.tar.gz" "${{ env.epn }}-${version}-md2png_${version}_Linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/app-text-mdsplit-bin-update.yaml
+++ b/.github/workflows/app-text-mdsplit-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: app-text/mdsplit-bin update
 
@@ -40,37 +40,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">arran4/mdsplit</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:arran4/mdsplit" --use-add "amd64:Enable amd64" --use-add "arm64:Enable arm64" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -95,8 +81,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -105,26 +91,20 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/mdsplit_\${PV}_linux_amd64.tar.gz -> \${P}-mdsplit_\${PV}_linux_amd64.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/mdsplit_\${PV}_linux_arm64.tar.gz -> \${P}-mdsplit_\${PV}_linux_arm64.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/mdsplit_\${PV}_linux_amd64.tar.gz -> \${P}-mdsplit_\${PV}_linux_amd64.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/mdsplit_\${PV}_linux_arm64.tar.gz -> \${P}-mdsplit_\${PV}_linux_arm64.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="MIT License"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
-                echo -n ''
-                echo -n ''
+                echo -n ' amd64 arm64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -147,19 +127,45 @@ jobs:
                 echo '    newexe "${{ env.mdsplit_binary_archived_name_arm64 }}" "${{ env.mdsplit_binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/mdsplit_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-mdsplit_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/mdsplit_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-mdsplit_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/mdsplit_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-mdsplit_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/mdsplit_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-mdsplit_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/app-text-mostcomm-bin-update.yaml
+++ b/.github/workflows/app-text-mostcomm-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: app-text/mostcomm-bin update
 
@@ -42,37 +42,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">arran4/mostcomm</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:arran4/mostcomm" --use-add "amd64:Enable amd64" --use-add "arm:Enable arm" --use-add "arm64:Enable arm64" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -97,8 +83,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -107,27 +93,22 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/mostcomm_\${PV}_linux_amd64.tar.gz -> \${P}-mostcomm_\${PV}_linux_amd64.tar.gz  )  "
-                echo "  arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/mostcomm_\${PV}_linux_armv7.tar.gz -> \${P}-mostcomm_\${PV}_linux_armv7.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/mostcomm_\${PV}_linux_arm64.tar.gz -> \${P}-mostcomm_\${PV}_linux_arm64.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/mostcomm_\${PV}_linux_amd64.tar.gz -> \${P}-mostcomm_\${PV}_linux_amd64.tar.gz  )  "
+                echo "	arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/mostcomm_\${PV}_linux_armv7.tar.gz -> \${P}-mostcomm_\${PV}_linux_armv7.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/mostcomm_\${PV}_linux_arm64.tar.gz -> \${P}-mostcomm_\${PV}_linux_arm64.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="MIT License"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
                 echo -n ' doc'
-                echo -n ''
+                echo -n ' amd64 arm arm64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -172,20 +153,46 @@ jobs:
                 echo '    fi'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/mostcomm_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-mostcomm_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/mostcomm_${version}_linux_armv7.tar.gz" "${{ env.epn }}-${version}-mostcomm_${version}_linux_armv7.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/mostcomm_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-mostcomm_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/mostcomm_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-mostcomm_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/mostcomm_${version}_linux_armv7.tar.gz" "${{ env.epn }}-${version}-mostcomm_${version}_linux_armv7.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/mostcomm_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-mostcomm_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/dev-go-goreleaser-bin-update.yaml
+++ b/.github/workflows/dev-go-goreleaser-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: dev-go/goreleaser-bin update
 
@@ -46,42 +46,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <use>
-              <flag name="bash">Install bash completion</flag>
-              <flag name="fish">Install fish completion</flag>
-              <flag name="zsh">Install zsh completion</flag>
-            </use>
-            <upstream>
-              <remote-id type="github">goreleaser/goreleaser</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:goreleaser/goreleaser" --use-add "amd64:Enable amd64" --use-add "arm:Enable arm" --use-add "arm64:Enable arm64" --use-add "bash:Install bash completion" --use-add "fish:Install fish completion" --use-add "ppc64:Enable ppc64" --use-add "x86:Enable x86" --use-add "zsh:Install zsh completion" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -106,8 +87,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -116,29 +97,26 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/goreleaser_Linux_x86_64.tar.gz -> \${P}-goreleaser_Linux_x86_64.tar.gz  )  "
-                echo "  arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/goreleaser_Linux_armv7.tar.gz -> \${P}-goreleaser_Linux_armv7.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/goreleaser_Linux_arm64.tar.gz -> \${P}-goreleaser_Linux_arm64.tar.gz  )  "
-                echo "  ppc64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/goreleaser_Linux_ppc64.tar.gz -> \${P}-goreleaser_Linux_ppc64.tar.gz  )  "
-                echo "  x86? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/goreleaser_Linux_i386.tar.gz -> \${P}-goreleaser_Linux_i386.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/goreleaser_Linux_x86_64.tar.gz -> \${P}-goreleaser_Linux_x86_64.tar.gz  )  "
+                echo "	arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/goreleaser_Linux_armv7.tar.gz -> \${P}-goreleaser_Linux_armv7.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/goreleaser_Linux_arm64.tar.gz -> \${P}-goreleaser_Linux_arm64.tar.gz  )  "
+                echo "	ppc64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/goreleaser_Linux_ppc64.tar.gz -> \${P}-goreleaser_Linux_ppc64.tar.gz  )  "
+                echo "	x86? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/goreleaser_Linux_i386.tar.gz -> \${P}-goreleaser_Linux_i386.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="MIT License"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
                 echo -n ' man'
                 echo -n ' doc'
                 echo -n ' bash fish zsh'
+                echo -n ' amd64 arm arm64 ppc64 x86'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -187,11 +165,11 @@ jobs:
                 echo '  fi'
                 echo '  if use fish; then'
                 echo '    insinto "/usr/share/fish/vendor_completions.d"'
-                echo '    newins "completions/goreleaser.fish" "goreleaser.fish" || die "Failed to fish completion file"'
+                echo '    newins "completions/goreleaser.fish" "goreleaser.fish" || die "Failed to bash completion file"'
                 echo '  fi'
                 echo '  if use zsh; then'
                 echo '    insinto "/usr/share/zsh/site-functions"'
-                echo '    newins "completions/goreleaser.zsh" "_goreleaser" || die "Failed to zsh completion file"'
+                echo '    newins "completions/goreleaser.zsh" "_goreleaser" || die "Failed to bash completion file"'
                 echo '  fi'
                 echo '  if use man; then'
                 echo '    newman "manpages/goreleaser.1" "goreleaser.1" || die "Failed to install manual page goreleaser.1"'
@@ -201,22 +179,48 @@ jobs:
                 echo '    newdoc "README.md" "README.md" || die "Failed to install document README.md"'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/goreleaser_Linux_x86_64.tar.gz" "${{ env.epn }}-${version}-goreleaser_Linux_x86_64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/goreleaser_Linux_armv7.tar.gz" "${{ env.epn }}-${version}-goreleaser_Linux_armv7.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/goreleaser_Linux_arm64.tar.gz" "${{ env.epn }}-${version}-goreleaser_Linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/goreleaser_Linux_ppc64.tar.gz" "${{ env.epn }}-${version}-goreleaser_Linux_ppc64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/goreleaser_Linux_i386.tar.gz" "${{ env.epn }}-${version}-goreleaser_Linux_i386.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/goreleaser_Linux_x86_64.tar.gz" "${{ env.epn }}-${version}-goreleaser_Linux_x86_64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/goreleaser_Linux_armv7.tar.gz" "${{ env.epn }}-${version}-goreleaser_Linux_armv7.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/goreleaser_Linux_arm64.tar.gz" "${{ env.epn }}-${version}-goreleaser_Linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/goreleaser_Linux_ppc64.tar.gz" "${{ env.epn }}-${version}-goreleaser_Linux_ppc64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/goreleaser_Linux_i386.tar.gz" "${{ env.epn }}-${version}-goreleaser_Linux_i386.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/dev-util-antigravity-cli-bin-update.yaml
+++ b/.github/workflows/dev-util-antigravity-cli-bin-update.yaml
@@ -1,17 +1,17 @@
 # Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
-name: app-misc/tuios-bin update
+name: dev-util/antigravity-cli-bin update
 
 permissions:
   contents: write
 
 on:
   schedule:
-    - cron: '24 9 * * *'
+    - cron: '59 1 * * *'
   workflow_dispatch:
   push:
     paths:
-      - '.github/workflows/app-misc-tuios-bin-update.yaml'
+      - '.github/workflows/dev-util-antigravity-cli-bin-update.yaml'
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -19,23 +19,19 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  ecn: app-misc
-  epn: tuios-bin
-  description: "Terminal UI OS (Terminal Multiplexer)"
-  homepage: "https://github.com/Gaurav-Gosain/tuios"
-  github_owner: Gaurav-Gosain
-  github_repo: tuios
-  keywords: ~amd64 ~arm ~arm64 ~x86
-  workflow_filename: app-misc-tuios-bin-update.yaml
-  tuios_binary_installed_name: 'tuios'
-  tuios_binary_archived_name_amd64: 'tuios'
-  tuios_release_name_amd64: 'tuios_\${PV}_Linux_x86_64.tar.gz'
-  tuios_binary_archived_name_arm: 'tuios'
-  tuios_release_name_arm: 'tuios_\${PV}_Linux_armv7.tar.gz'
-  tuios_binary_archived_name_arm64: 'tuios'
-  tuios_release_name_arm64: 'tuios_\${PV}_Linux_arm64.tar.gz'
-  tuios_binary_archived_name_x86: 'tuios'
-  tuios_release_name_x86: 'tuios_\${PV}_Linux_i386.tar.gz'
+  ecn: dev-util
+  epn: antigravity-cli-bin
+  description: "Antigravity CLI"
+  homepage: "https://github.com/google-antigravity/antigravity-cli"
+  github_owner: google-antigravity
+  github_repo: antigravity-cli
+  keywords: ~amd64 ~arm64
+  workflow_filename: dev-util-antigravity-cli-bin-update.yaml
+  antigravity_binary_installed_name: 'antigravity'
+  antigravity_binary_archived_name_amd64: 'antigravity'
+  antigravity_release_name_amd64: 'agy_cli_linux_x64.tar.gz'
+  antigravity_binary_archived_name_arm64: 'antigravity'
+  antigravity_release_name_arm64: 'agy_cli_linux_arm64.tar.gz'
 
 jobs:
   check-and-create-ebuild:
@@ -58,7 +54,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:Gaurav-Gosain/tuios" --use-add "amd64:Enable amd64" --use-add "arm:Enable arm" --use-add "arm64:Enable arm64" --use-add "x86:Enable x86" "$metadata_file"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:google-antigravity/antigravity-cli" --use-add "amd64:Enable amd64" --use-add "arm64:Enable arm64" "$metadata_file"
           declare -A releaseTypes=()
           tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
@@ -95,17 +91,14 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/tuios_\${PV}_Linux_x86_64.tar.gz -> \${P}-tuios_\${PV}_Linux_x86_64.tar.gz  )  "
-                echo "	arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/tuios_\${PV}_Linux_armv7.tar.gz -> \${P}-tuios_\${PV}_Linux_armv7.tar.gz  )  "
-                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/tuios_\${PV}_Linux_arm64.tar.gz -> \${P}-tuios_\${PV}_Linux_arm64.tar.gz  )  "
-                echo "	x86? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/tuios_\${PV}_Linux_i386.tar.gz -> \${P}-tuios_\${PV}_Linux_i386.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/agy_cli_linux_x64.tar.gz -> \${P}-agy_cli_linux_x64.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/agy_cli_linux_arm64.tar.gz -> \${P}-agy_cli_linux_arm64.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT License"'
+                echo 'LICENSE="Apache-2.0"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ' doc'
-                echo -n ' amd64 arm arm64 x86'
+                echo -n ' amd64 arm64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
@@ -118,36 +111,20 @@ jobs:
                 echo ''
                 echo 'src_unpack() {'
                 echo '  if use amd64; then'
-                echo "    unpack \"\${DISTDIR}/\${P}-tuios_\${PV}_Linux_x86_64.tar.gz\" || die \"Can't unpack archive file\""
-                echo '  fi'
-                echo '  if use arm; then'
-                echo "    unpack \"\${DISTDIR}/\${P}-tuios_\${PV}_Linux_armv7.tar.gz\" || die \"Can't unpack archive file\""
+                echo "    unpack \"\${DISTDIR}/\${P}-agy_cli_linux_x64.tar.gz\" || die \"Can't unpack archive file\""
                 echo '  fi'
                 echo '  if use arm64; then'
-                echo "    unpack \"\${DISTDIR}/\${P}-tuios_\${PV}_Linux_arm64.tar.gz\" || die \"Can't unpack archive file\""
-                echo '  fi'
-                echo '  if use x86; then'
-                echo "    unpack \"\${DISTDIR}/\${P}-tuios_\${PV}_Linux_i386.tar.gz\" || die \"Can't unpack archive file\""
+                echo "    unpack \"\${DISTDIR}/\${P}-agy_cli_linux_arm64.tar.gz\" || die \"Can't unpack archive file\""
                 echo '  fi'
                 echo '}'
                 echo ''
                 echo 'src_install() {'
                 echo '  exeinto /opt/bin'
                 echo '  if use amd64; then'
-                echo '    newexe "${{ env.tuios_binary_archived_name_amd64 }}" "${{ env.tuios_binary_installed_name }}" || die "Failed to install Binary"'
-                echo '  fi'
-                echo '  if use arm; then'
-                echo '    newexe "${{ env.tuios_binary_archived_name_arm }}" "${{ env.tuios_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '    newexe "${{ env.antigravity_binary_archived_name_amd64 }}" "${{ env.antigravity_binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
                 echo '  if use arm64; then'
-                echo '    newexe "${{ env.tuios_binary_archived_name_arm64 }}" "${{ env.tuios_binary_installed_name }}" || die "Failed to install Binary"'
-                echo '  fi'
-                echo '  if use x86; then'
-                echo '    newexe "${{ env.tuios_binary_archived_name_x86 }}" "${{ env.tuios_binary_installed_name }}" || die "Failed to install Binary"'
-                echo '  fi'
-                echo '  if use doc; then'
-                echo '    newdoc "LICENSE" "LICENSE" || die "Failed to install document LICENSE"'
-                echo '    newdoc "README.md" "README.md" || die "Failed to install document README.md"'
+                echo '    newexe "${{ env.antigravity_binary_archived_name_arm64 }}" "${{ env.antigravity_binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
                 echo '}'
               } > "$tmp_ebuild_file"
@@ -163,10 +140,8 @@ jobs:
               fi
               # Manifest generation
               failed=0
-              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/tuios_${version}_Linux_x86_64.tar.gz" "${{ env.epn }}-${version}-tuios_${version}_Linux_x86_64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
-              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/tuios_${version}_Linux_armv7.tar.gz" "${{ env.epn }}-${version}-tuios_${version}_Linux_armv7.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
-              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/tuios_${version}_Linux_arm64.tar.gz" "${{ env.epn }}-${version}-tuios_${version}_Linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
-              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/tuios_${version}_Linux_i386.tar.gz" "${{ env.epn }}-${version}-tuios_${version}_Linux_i386.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/agy_cli_linux_x64.tar.gz" "${{ env.epn }}-${version}-agy_cli_linux_x64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/agy_cli_linux_arm64.tar.gz" "${{ env.epn }}-${version}-agy_cli_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
               if [ "$failed" -eq 1 ]; then
                   echo "Failed to generate manifest for $tag. Skipping..."
                   rm -f "$ebuild_file"

--- a/.github/workflows/dev-util-codex-bin-update.yaml
+++ b/.github/workflows/dev-util-codex-bin-update.yaml
@@ -60,19 +60,9 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<EOF > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-          <upstream>
-          <remote-id type="github">openai/codex</remote-id>
-          </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:${{ env.github_owner }}/${{ env.github_repo }}" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#rust-v}"
@@ -99,8 +89,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -151,21 +141,37 @@ jobs:
                 echo '    newexe "${{ env.codex_binary_archived_name_arm64 }}" "${{ env.codex_binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
 
               # Manifest generation
 
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/codex-x86_64-unknown-linux-musl.tar.gz" "${{ env.epn }}-${version}-codex-x86_64-unknown-linux-musl.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/codex-aarch64-unknown-linux-musl.tar.gz" "${{ env.epn }}-${version}-codex-aarch64-unknown-linux-musl.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/codex-x86_64-unknown-linux-musl.tar.gz" "${{ env.epn }}-${version}-codex-x86_64-unknown-linux-musl.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/codex-aarch64-unknown-linux-musl.tar.gz" "${{ env.epn }}-${version}-codex-aarch64-unknown-linux-musl.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          if git commit -m "Add ebuild for ${{ env.epn }} version ${{ steps.process_releases.outputs.generated_tag }}"; then
+          if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push
           fi || true

--- a/.github/workflows/dev-util-editorconfig-guesser-bin-update.yaml
+++ b/.github/workflows/dev-util-editorconfig-guesser-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: dev-util/editorconfig-guesser-bin update
 
@@ -42,37 +42,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">arran4/editorconfig-guesser</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:arran4/editorconfig-guesser" --use-add "amd64:Enable amd64" --use-add "arm:Enable arm" --use-add "arm64:Enable arm64" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -97,8 +83,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -107,27 +93,22 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/ecguess_\${PV}_linux_amd64.tar.gz -> \${P}-ecguess_\${PV}_linux_amd64.tar.gz  )  "
-                echo "  arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/ecguess_\${PV}_linux_armv7.tar.gz -> \${P}-ecguess_\${PV}_linux_armv7.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/ecguess_\${PV}_linux_arm64.tar.gz -> \${P}-ecguess_\${PV}_linux_arm64.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/ecguess_\${PV}_linux_amd64.tar.gz -> \${P}-ecguess_\${PV}_linux_amd64.tar.gz  )  "
+                echo "	arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/ecguess_\${PV}_linux_armv7.tar.gz -> \${P}-ecguess_\${PV}_linux_armv7.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/ecguess_\${PV}_linux_arm64.tar.gz -> \${P}-ecguess_\${PV}_linux_arm64.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="MIT License"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
                 echo -n ' doc'
-                echo -n ''
+                echo -n ' amd64 arm arm64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -172,20 +153,46 @@ jobs:
                 echo '    fi'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/ecguess_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-ecguess_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/ecguess_${version}_linux_armv7.tar.gz" "${{ env.epn }}-${version}-ecguess_${version}_linux_armv7.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/ecguess_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-ecguess_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/ecguess_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-ecguess_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/ecguess_${version}_linux_armv7.tar.gz" "${{ env.epn }}-${version}-ecguess_${version}_linux_armv7.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/ecguess_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-ecguess_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/dev-util-layerx-bin-update.yaml
+++ b/.github/workflows/dev-util-layerx-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-06-12 00:12:54.421454853 +0000 UTC m=+0.005987182
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: dev-util/layerx-bin update
 
@@ -18,6 +18,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   ecn: dev-util
   epn: layerx-bin
   description: "Interactive Docker image layer inspector"
@@ -37,27 +38,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
-            if command -v go &> /dev/null
-            then
-                go install github.com/arran4/g2/cmd/g2@latest
-            else
-                url="$(curl -s --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/arran4/g2/releases/latest | jq -r '.assets[].browser_download_url | select(endswith("_linux_amd64.deb"))')"
-                echo "$url"
-                wget "${url}" -O /tmp/g2.deb
-                sudo dpkg -i /tmp/g2.deb
-                rm /tmp/g2.deb
-            fi
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
 
       - name: Process each release
         id: process_releases
@@ -65,19 +54,9 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<- 'EOF' > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">deveshctl/layerx</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
-          declare -A releaseTypes
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:deveshctl/layerx" --use-add "amd64:Enable amd64" --use-add "arm64:Enable arm64" "$metadata_file"
+          declare -A releaseTypes=()
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -91,7 +70,7 @@ jobs:
                 echo "tag / $version doesn't match regexp";
                 continue;
             fi
-            releaseType="$(echo "${version}" | sed -n 's/^[^_]\+_\(alpha\|beta\|rc\|p[0-9]*\).*$/\1/p')" || true
+            releaseType="$(echo "${version}" | sed -n 's/^[^_]\+_\(alpha\|beta\|rc\|p[0-9]*\).*$/\1/p')"
             if [[ ! -v releaseTypes[${releaseType:=release}] ]]; then
                 if [[ -v releaseTypes[release] ]]; then
                   echo "Already have a newer main release: ${releaseTypes[release]}"
@@ -102,8 +81,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -112,26 +91,20 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/layerx_linux_amd64.tar.gz -> \${P}-layerx_linux_amd64.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/layerx_linux_arm64.tar.gz -> \${P}-layerx_linux_arm64.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/layerx_linux_amd64.tar.gz -> \${P}-layerx_linux_amd64.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/layerx_linux_arm64.tar.gz -> \${P}-layerx_linux_arm64.tar.gz  )  "
                 echo '"'
                 echo 'LICENSE="MIT"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
-                echo -n ''
-                echo -n ''
+                echo -n ' amd64 arm64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -154,21 +127,45 @@ jobs:
                 echo '    newexe "${{ env.layerx_binary_archived_name_arm64 }}" "${{ env.layerx_binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-              export PATH; PATH="$(go env GOPATH)/bin:$PATH"
-
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/layerx_linux_amd64.tar.gz" "${{ env.epn }}-${version}-layerx_linux_amd64.tar.gz" "${ebuild_dir}"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/layerx_linux_arm64.tar.gz" "${{ env.epn }}-${version}-layerx_linux_arm64.tar.gz" "${ebuild_dir}"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/layerx_linux_amd64.tar.gz" "${{ env.epn }}-${version}-layerx_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/layerx_linux_arm64.tar.gz" "${{ env.epn }}-${version}-layerx_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/dev-vcs-git-credential-oauth-bin-update.yaml
+++ b/.github/workflows/dev-vcs-git-credential-oauth-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: dev-vcs/git-credential-oauth-bin update
 
@@ -42,37 +42,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">hickford/git-credential-oauth</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:hickford/git-credential-oauth" --use-add "amd64:Enable amd64" --use-add "arm64:Enable arm64" --use-add "x86:Enable x86" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -97,8 +83,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -107,27 +93,23 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/git-credential-oauth_\${PV}_linux_amd64.tar.gz -> \${P}-git-credential-oauth_\${PV}_linux_amd64.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/git-credential-oauth_\${PV}_linux_arm64.tar.gz -> \${P}-git-credential-oauth_\${PV}_linux_arm64.tar.gz  )  "
-                echo "  x86? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/git-credential-oauth_\${PV}_linux_386.tar.gz -> \${P}-git-credential-oauth_\${PV}_linux_386.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/git-credential-oauth_\${PV}_linux_amd64.tar.gz -> \${P}-git-credential-oauth_\${PV}_linux_amd64.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/git-credential-oauth_\${PV}_linux_arm64.tar.gz -> \${P}-git-credential-oauth_\${PV}_linux_arm64.tar.gz  )  "
+                echo "	x86? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/git-credential-oauth_\${PV}_linux_386.tar.gz -> \${P}-git-credential-oauth_\${PV}_linux_386.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="MIT License"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
                 echo -n ' doc'
-                echo -n ''
+                echo -n ' amd64 arm64 x86'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
                 echo -n 'sys-devel/gcc '
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -160,20 +142,46 @@ jobs:
                 echo '    newdoc "README.md" "README.md" || die "Failed to install document README.md"'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/git-credential-oauth_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-git-credential-oauth_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/git-credential-oauth_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-git-credential-oauth_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/git-credential-oauth_${version}_linux_386.tar.gz" "${{ env.epn }}-${version}-git-credential-oauth_${version}_linux_386.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/git-credential-oauth_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-git-credential-oauth_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/git-credential-oauth_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-git-credential-oauth_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/git-credential-oauth_${version}_linux_386.tar.gz" "${{ env.epn }}-${version}-git-credential-oauth_${version}_linux_386.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/dev-vcs-git-tag-inc-bin-update.yaml
+++ b/.github/workflows/dev-vcs-git-tag-inc-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: dev-vcs/git-tag-inc-bin update
 
@@ -42,37 +42,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">arran4/git-tag-inc</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:arran4/git-tag-inc" --use-add "amd64:Enable amd64" --use-add "arm:Enable arm" --use-add "arm64:Enable arm64" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -97,8 +83,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -107,27 +93,22 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/git-tag-inc_\${PV}_linux_amd64.tar.gz -> \${P}-git-tag-inc_\${PV}_linux_amd64.tar.gz  )  "
-                echo "  arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/git-tag-inc_\${PV}_linux_armv7.tar.gz -> \${P}-git-tag-inc_\${PV}_linux_armv7.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/git-tag-inc_\${PV}_linux_arm64.tar.gz -> \${P}-git-tag-inc_\${PV}_linux_arm64.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/git-tag-inc_\${PV}_linux_amd64.tar.gz -> \${P}-git-tag-inc_\${PV}_linux_amd64.tar.gz  )  "
+                echo "	arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/git-tag-inc_\${PV}_linux_armv7.tar.gz -> \${P}-git-tag-inc_\${PV}_linux_armv7.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/git-tag-inc_\${PV}_linux_arm64.tar.gz -> \${P}-git-tag-inc_\${PV}_linux_arm64.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="unknown"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
                 echo -n ' doc'
-                echo -n ''
+                echo -n ' amd64 arm arm64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -168,20 +149,46 @@ jobs:
                 echo '    fi'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/git-tag-inc_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-git-tag-inc_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/git-tag-inc_${version}_linux_armv7.tar.gz" "${{ env.epn }}-${version}-git-tag-inc_${version}_linux_armv7.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/git-tag-inc_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-git-tag-inc_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/git-tag-inc_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-git-tag-inc_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/git-tag-inc_${version}_linux_armv7.tar.gz" "${{ env.epn }}-${version}-git-tag-inc_${version}_linux_armv7.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/git-tag-inc_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-git-tag-inc_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/media-sound-go-playerctl-bin-update.yaml
+++ b/.github/workflows/media-sound-go-playerctl-bin-update.yaml
@@ -58,19 +58,9 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            {
-              echo '<?xml version="1.0" encoding="UTF-8"?>'
-              echo '<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">'
-              echo '<pkgmetadata>'
-              echo '  <upstream>'
-              echo '    <remote-id type="github">mariusor/go-playerctl</remote-id>'
-              echo '  </upstream>'
-              echo '</pkgmetadata>'
-            } > "$metadata_file"
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:${{ env.github_owner }}/${{ env.github_repo }}" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -95,8 +85,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -152,19 +142,35 @@ jobs:
                 echo '  fi'
                 echo '  dosym go-playerctl /usr/bin/go-playerctld'
                 echo '}'
-              } > $ebuild_file
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
 
               # Manifest generation
 
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/go-playerctl_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-go-playerctl_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/go-playerctl_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-go-playerctl_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/go-playerctl_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-go-playerctl_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/go-playerctl_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-go-playerctl_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/net-im-caprine-appimage-update.yaml
+++ b/.github/workflows/net-im-caprine-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github AppImage Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github AppImage Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: net-im/caprine-appimage update
 
@@ -38,37 +38,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">sindresorhus/caprine</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:sindresorhus/caprine" "$metadata_file"
           declare -A releaseTypes=()
-            tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -89,8 +75,8 @@ jobs:
                 echo "Already have a newier ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -98,12 +84,12 @@ jobs:
                 echo 'EAPI=8'
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="MIT License"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo 'IUSE=""'
                 echo 'DEPEND=""'
-                echo 'RDEPEND="sys-libs/glibc sys-libs/zlib "'
+                echo 'RDEPEND="sys-fs/fuse:0 sys-fs/fuse:0 sys-libs/glibc sys-libs/zlib"'
                 echo 'S="${WORKDIR}"'
                 echo 'RESTRICT="strip"'
                 echo ''
@@ -145,18 +131,45 @@ jobs:
                 echo "  xdg_desktop_database_update"
                 echo "}"
                 echo ""
-              } > $ebuild_file
 
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/Caprine-${version}.AppImage" "${{ env.epn }}-${version}-Caprine-${version}.AppImage" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/Caprine-${version}.AppImage" "${{ env.epn }}-${version}-Caprine-${version}.AppImage" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/net-im-lemmy-notify-appimage-update.yaml
+++ b/.github/workflows/net-im-lemmy-notify-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github AppImage Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github AppImage Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: net-im/lemmy-notify-appimage update
 
@@ -38,37 +38,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">arran4/lemmy_notify</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:arran4/lemmy_notify" "$metadata_file"
           declare -A releaseTypes=()
-            tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -89,8 +75,8 @@ jobs:
                 echo "Already have a newier ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -98,12 +84,12 @@ jobs:
                 echo 'EAPI=8'
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="unknown"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo 'IUSE=""'
                 echo 'DEPEND=""'
-                echo 'RDEPEND="sys-libs/glibc sys-libs/zlib "'
+                echo 'RDEPEND="sys-fs/fuse:0 sys-fs/fuse:0 sys-libs/glibc sys-libs/zlib"'
                 echo 'S="${WORKDIR}"'
                 echo 'RESTRICT="strip"'
                 echo ''
@@ -145,18 +131,45 @@ jobs:
                 echo "  xdg_desktop_database_update"
                 echo "}"
                 echo ""
-              } > $ebuild_file
 
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/lemmy_notify-linux-x86_64.AppImage" "${{ env.epn }}-${version}-lemmy_notify-linux-x86_64.AppImage" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/lemmy_notify-linux-x86_64.AppImage" "${{ env.epn }}-${version}-lemmy_notify-linux-x86_64.AppImage" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/net-im-slackdump-bin-update.yaml
+++ b/.github/workflows/net-im-slackdump-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: net-im/slackdump-bin update
 
@@ -42,37 +42,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">rusq/slackdump</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:rusq/slackdump" --use-add "amd64:Enable amd64" --use-add "arm64:Enable arm64" --use-add "x86:Enable x86" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -98,8 +84,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -108,27 +94,21 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/slackdump_Linux_x86_64.tar.gz -> \${P}-slackdump_Linux_x86_64.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/slackdump_Linux_arm64.tar.gz -> \${P}-slackdump_Linux_arm64.tar.gz  )  "
-                echo "  x86? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/slackdump_Linux_i386.tar.gz -> \${P}-slackdump_Linux_i386.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/slackdump_Linux_x86_64.tar.gz -> \${P}-slackdump_Linux_x86_64.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/slackdump_Linux_arm64.tar.gz -> \${P}-slackdump_Linux_arm64.tar.gz  )  "
+                echo "	x86? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/slackdump_Linux_i386.tar.gz -> \${P}-slackdump_Linux_i386.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="GNU General Public License v3.0"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
-                echo -n ''
-                echo -n ''
+                echo -n ' amd64 arm64 x86'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -157,20 +137,46 @@ jobs:
                 echo '    newexe "${{ env.binary_archived_name_x86 }}" "${{ env.binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/slackdump_Linux_x86_64.tar.gz" "${{ env.epn }}-${version}-slackdump_Linux_x86_64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/slackdump_Linux_arm64.tar.gz" "${{ env.epn }}-${version}-slackdump_Linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/slackdump_Linux_i386.tar.gz" "${{ env.epn }}-${version}-slackdump_Linux_i386.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/slackdump_Linux_x86_64.tar.gz" "${{ env.epn }}-${version}-slackdump_Linux_x86_64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/slackdump_Linux_arm64.tar.gz" "${{ env.epn }}-${version}-slackdump_Linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/slackdump_Linux_i386.tar.gz" "${{ env.epn }}-${version}-slackdump_Linux_i386.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/net-misc-abc-justin-rss-bin-update.yaml
+++ b/.github/workflows/net-misc-abc-justin-rss-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-04-05 01:55:06.204301494 +0000 UTC m=+0.005775569
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: net-misc/abc-justin-rss-bin update
 
@@ -41,18 +41,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Install g2 tool
-        uses: arran4/g2-action@v1.2
 
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
 
       - name: Process each release
         id: process_releases
@@ -60,19 +56,9 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            {
-              echo '<?xml version="1.0" encoding="UTF-8"?>'
-              echo '<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">'
-              echo '<pkgmetadata>'
-              echo '	<upstream>'
-              echo '		<remote-id type="github">arran4/abc-justin-rss</remote-id>'
-              echo '	</upstream>'
-              echo '</pkgmetadata>'
-            } > "$metadata_file"
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:arran4/abc-justin-rss" --use-add "amd64:Enable amd64" --use-add "arm64:Enable arm64" --use-add "x86:Enable x86" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -97,8 +83,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -115,19 +101,14 @@ jobs:
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
                 echo -n ' doc'
-                echo -n ''
+                echo -n ' amd64 arm64 x86'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -145,7 +126,7 @@ jobs:
                 echo '}'
                 echo ''
                 echo 'src_install() {'
-                echo '  exeinto /usr/bin'
+                echo '  exeinto /opt/bin'
                 echo '  if use amd64; then'
                 echo '    newexe "${{ env.abcjustinrss_binary_archived_name_amd64 }}" "${{ env.abcjustinrss_binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
@@ -160,20 +141,46 @@ jobs:
                 echo '    newdoc "readme.md" "README.md" || die "Failed to install document README.md"'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/abcjustinrss_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-abcjustinrss_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/abcjustinrss_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-abcjustinrss_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/abcjustinrss_${version}_linux_386.tar.gz" "${{ env.epn }}-${version}-abcjustinrss_${version}_linux_386.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/abcjustinrss_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-abcjustinrss_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/abcjustinrss_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-abcjustinrss_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/abcjustinrss_${version}_linux_386.tar.gz" "${{ env.epn }}-${version}-abcjustinrss_${version}_linux_386.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/net-misc-localsend-appimage-update.yaml
+++ b/.github/workflows/net-misc-localsend-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github AppImage Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github AppImage Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: net-misc/localsend-appimage update
 
@@ -38,37 +38,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">localsend/localsend</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:localsend/localsend" "$metadata_file"
           declare -A releaseTypes=()
-            tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -89,8 +75,8 @@ jobs:
                 echo "Already have a newier ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -98,12 +84,12 @@ jobs:
                 echo 'EAPI=8'
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="MIT License"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo 'IUSE=""'
                 echo 'DEPEND=""'
-                echo 'RDEPEND="sys-libs/glibc sys-libs/zlib "'
+                echo 'RDEPEND="sys-fs/fuse:0 sys-fs/fuse:0 sys-libs/glibc sys-libs/zlib"'
                 echo 'S="${WORKDIR}"'
                 echo 'RESTRICT="strip"'
                 echo ''
@@ -145,18 +131,45 @@ jobs:
                 echo "  xdg_desktop_database_update"
                 echo "}"
                 echo ""
-              } > $ebuild_file
 
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/LocalSend-${version}-linux-x86-64.AppImage" "${{ env.epn }}-${version}-LocalSend-${version}-linux-x86-64.AppImage" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/LocalSend-${version}-linux-x86-64.AppImage" "${{ env.epn }}-${version}-LocalSend-${version}-linux-x86-64.AppImage" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/net-misc-pimtrace-bin-update.yaml
+++ b/.github/workflows/net-misc-pimtrace-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: net-misc/pimtrace-bin update
 
@@ -40,37 +40,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">arran4/pimtrace</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:arran4/pimtrace" --use-add "amd64:Enable amd64" --use-add "arm64:Enable arm64" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -95,8 +81,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -105,26 +91,21 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/pimtrace_\${PV}_linux_amd64.tar.gz -> \${P}-pimtrace_\${PV}_linux_amd64.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/pimtrace_\${PV}_linux_arm64.tar.gz -> \${P}-pimtrace_\${PV}_linux_arm64.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/pimtrace_\${PV}_linux_amd64.tar.gz -> \${P}-pimtrace_\${PV}_linux_amd64.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/pimtrace_\${PV}_linux_arm64.tar.gz -> \${P}-pimtrace_\${PV}_linux_arm64.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="Other"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
                 echo -n ' doc'
-                echo -n ''
+                echo -n ' amd64 arm64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -155,19 +136,45 @@ jobs:
                 echo '    newdoc "readme.MD" "readme.MD" || die "Failed to install document readme.MD"'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/pimtrace_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-pimtrace_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/pimtrace_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-pimtrace_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/pimtrace_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-pimtrace_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/pimtrace_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-pimtrace_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/net-misc-podcast-cdr-manager-bin-update.yaml
+++ b/.github/workflows/net-misc-podcast-cdr-manager-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: net-misc/podcast-cdr-manager-bin update
 
@@ -29,11 +29,11 @@ env:
   workflow_filename: net-misc-podcast-cdr-manager-bin-update.yaml
   podcastcdrmanager_binary_installed_name: 'podcastcdrmanager'
   podcastcdrmanager_binary_archived_name_amd64: 'podcastcdrmanager'
-  podcastcdrmanager_release_name_amd64: 'podcastcdrmanager_${version}_linux_amd64.tar.gz'
+  podcastcdrmanager_release_name_amd64: 'podcastcdrmanager_\${PV}_linux_amd64.tar.gz'
   podcastcdrmanager_binary_archived_name_arm: 'podcastcdrmanager'
-  podcastcdrmanager_release_name_arm: 'podcastcdrmanager_${version}_linux_armv6.tar.gz'
+  podcastcdrmanager_release_name_arm: 'podcastcdrmanager_\${PV}_linux_armv6.tar.gz'
   podcastcdrmanager_binary_archived_name_arm64: 'podcastcdrmanager'
-  podcastcdrmanager_release_name_arm64: 'podcastcdrmanager_${version}_linux_arm64.tar.gz'
+  podcastcdrmanager_release_name_arm64: 'podcastcdrmanager_\${PV}_linux_arm64.tar.gz'
 
 jobs:
   check-and-create-ebuild:
@@ -42,37 +42,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">arran4/podcast-cdr-manager</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:arran4/podcast-cdr-manager" --use-add "amd64:Enable amd64" --use-add "arm:Enable arm" --use-add "arm64:Enable arm64" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -97,8 +83,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -107,27 +93,22 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/podcastcdrmanager_\${PV}_linux_amd64.tar.gz -> \${P}-podcastcdrmanager_\${PV}_linux_amd64.tar.gz  )  "
-                echo "  arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/podcastcdrmanager_\${PV}_linux_armv6.tar.gz -> \${P}-podcastcdrmanager_\${PV}_linux_armv6.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/podcastcdrmanager_\${PV}_linux_arm64.tar.gz -> \${P}-podcastcdrmanager_\${PV}_linux_arm64.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/podcastcdrmanager_\${PV}_linux_amd64.tar.gz -> \${P}-podcastcdrmanager_\${PV}_linux_amd64.tar.gz  )  "
+                echo "	arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/podcastcdrmanager_\${PV}_linux_armv6.tar.gz -> \${P}-podcastcdrmanager_\${PV}_linux_armv6.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/podcastcdrmanager_\${PV}_linux_arm64.tar.gz -> \${P}-podcastcdrmanager_\${PV}_linux_arm64.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="unknown"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
                 echo -n ' doc'
-                echo -n ''
+                echo -n ' amd64 arm arm64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -159,20 +140,46 @@ jobs:
                 echo '    newdoc "readme.md" "readme.md" || die "Failed to install document readme.md"'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/podcastcdrmanager_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-podcastcdrmanager_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/podcastcdrmanager_${version}_linux_armv6.tar.gz" "${{ env.epn }}-${version}-podcastcdrmanager_${version}_linux_armv6.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/podcastcdrmanager_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-podcastcdrmanager_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/podcastcdrmanager_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-podcastcdrmanager_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/podcastcdrmanager_${version}_linux_armv6.tar.gz" "${{ env.epn }}-${version}-podcastcdrmanager_${version}_linux_armv6.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/podcastcdrmanager_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-podcastcdrmanager_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/net-misc-reddit-tui-bin-update.yaml
+++ b/.github/workflows/net-misc-reddit-tui-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: net-misc/reddit-tui-bin update
 
@@ -40,37 +40,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">tonymajestro/reddit-tui</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:tonymajestro/reddit-tui" --use-add "amd64:Enable amd64" --use-add "arm64:Enable arm64" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -95,8 +81,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -105,26 +91,21 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/reddit-tui_Linux_x86_64.tar.gz -> \${P}-reddit-tui_Linux_x86_64.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/reddit-tui_Linux_arm64.tar.gz -> \${P}-reddit-tui_Linux_arm64.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/reddit-tui_Linux_x86_64.tar.gz -> \${P}-reddit-tui_Linux_x86_64.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/reddit-tui_Linux_arm64.tar.gz -> \${P}-reddit-tui_Linux_arm64.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="MIT License"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
                 echo -n ' doc'
-                echo -n ''
+                echo -n ' amd64 arm64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -153,19 +134,45 @@ jobs:
                 echo '    fi'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/reddit-tui_Linux_x86_64.tar.gz" "${{ env.epn }}-${version}-reddit-tui_Linux_x86_64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/reddit-tui_Linux_arm64.tar.gz" "${{ env.epn }}-${version}-reddit-tui_Linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/reddit-tui_Linux_x86_64.tar.gz" "${{ env.epn }}-${version}-reddit-tui_Linux_x86_64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/reddit-tui_Linux_arm64.tar.gz" "${{ env.epn }}-${version}-reddit-tui_Linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/net-misc-rustdesk-appimage-update.yaml
+++ b/.github/workflows/net-misc-rustdesk-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github AppImage Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github AppImage Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: net-misc/rustdesk-appimage update
 
@@ -39,37 +39,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">rustdesk/rustdesk</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:rustdesk/rustdesk" "$metadata_file"
           declare -A releaseTypes=()
-            tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag}"
@@ -87,8 +73,8 @@ jobs:
                 echo "Already have a newier ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -96,12 +82,12 @@ jobs:
                 echo 'EAPI=8'
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="GNU Affero General Public License v3.0"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo 'IUSE=""'
                 echo 'DEPEND=""'
-                echo 'RDEPEND="sys-libs/glibc sys-libs/glibc sys-libs/zlib sys-libs/zlib "'
+                echo 'RDEPEND="sys-fs/fuse:0 sys-fs/fuse:0 sys-libs/glibc sys-libs/zlib"'
                 echo 'S="${WORKDIR}"'
                 echo 'RESTRICT="strip"'
                 echo ''
@@ -144,19 +130,46 @@ jobs:
                 echo "  xdg_desktop_database_update"
                 echo "}"
                 echo ""
-              } > $ebuild_file
 
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/rustdesk-${tag}-aarch64.AppImage" "${{ env.epn }}-${version}-rustdesk-${tag}-aarch64.AppImage" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/rustdesk-${tag}-x86_64.AppImage" "${{ env.epn }}-${version}-rustdesk-${tag}-x86_64.AppImage" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/rustdesk-${tag}-aarch64.AppImage" "${{ env.epn }}-${version}-rustdesk-${tag}-aarch64.AppImage" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/rustdesk-${tag}-x86_64.AppImage" "${{ env.epn }}-${version}-rustdesk-${tag}-x86_64.AppImage" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/sys-apps-lxa-bin-update.yaml
+++ b/.github/workflows/sys-apps-lxa-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-25 10:46:08.355218676 +0000 UTC m=+0.010058064
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: sys-apps/lxa-bin update
 
@@ -39,17 +39,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - uses: arran4/g2-action@v1.2
 
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
 
       - name: Process each release
         id: process_releases
@@ -57,19 +54,9 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            {
-              echo '<?xml version="1.0" encoding="UTF-8"?>'
-              echo '<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">'
-              echo '<pkgmetadata>'
-              echo '  <upstream>'
-              echo '    <remote-id type="github">arran4/lxa</remote-id>'
-              echo '  </upstream>'
-              echo '</pkgmetadata>'
-            } > "$metadata_file"
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:arran4/lxa" --use-add "amd64:Enable amd64" --use-add "arm64:Enable arm64" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -94,8 +81,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -104,26 +91,21 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/lxa_\${PV}_linux_amd64.tar.gz -> \${P}-lxa_\${PV}_linux_amd64.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/lxa_\${PV}_linux_arm64.tar.gz -> \${P}-lxa_\${PV}_linux_arm64.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/lxa_\${PV}_linux_amd64.tar.gz -> \${P}-lxa_\${PV}_linux_amd64.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/lxa_\${PV}_linux_arm64.tar.gz -> \${P}-lxa_\${PV}_linux_arm64.tar.gz  )  "
                 echo '"'
                 echo 'LICENSE="MIT"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
                 echo -n ' doc'
-                echo -n ''
+                echo -n ' amd64 arm64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -138,7 +120,7 @@ jobs:
                 echo '}'
                 echo ''
                 echo 'src_install() {'
-                echo '  exeinto /usr/bin'
+                echo '  exeinto /opt/bin'
                 echo '  if use amd64; then'
                 echo '    newexe "${{ env.lxa_binary_archived_name_amd64 }}" "${{ env.lxa_binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
@@ -149,19 +131,45 @@ jobs:
                 echo '    newdoc "README.md" "README.md" || die "Failed to install document README.md"'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/lxa_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-lxa_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/lxa_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-lxa_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/lxa_${version}_linux_amd64.tar.gz" "${{ env.epn }}-${version}-lxa_${version}_linux_amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/lxa_${version}_linux_arm64.tar.gz" "${{ env.epn }}-${version}-lxa_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/www-apps-hugo-bin-update.yaml
+++ b/.github/workflows/www-apps-hugo-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: www-apps/hugo-bin update
 
@@ -47,40 +47,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <use>
-              <flag name="extended">Install extended binary</flag>
-            </use>
-            <upstream>
-              <remote-id type="github">gohugoio/hugo</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:gohugoio/hugo" --use-add "amd64:Enable amd64" --use-add "arm:Enable arm" --use-add "arm64:Enable arm64" --use-add "extended:Install extended binary" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -105,8 +88,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -115,20 +98,18 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? ( !extended? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/hugo_\${PV}_linux-amd64.tar.gz -> \${P}-hugo_\${PV}_linux-amd64.tar.gz  )  )  "
-                echo "  amd64? ( extended? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/hugo_extended_\${PV}_Linux-64bit.tar.gz -> \${P}-hugo_extended_\${PV}_Linux-64bit.tar.gz  )  )  "
-                echo "  arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/hugo_\${PV}_linux-arm.tar.gz -> \${P}-hugo_\${PV}_linux-arm.tar.gz  )  "
-                echo "  arm64? ( !extended? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/hugo_\${PV}_linux-arm64.tar.gz -> \${P}-hugo_\${PV}_linux-arm64.tar.gz  )  )  "
-                echo "  arm64? ( extended? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/hugo_extended_\${PV}_linux-arm64.tar.gz -> \${P}-hugo_extended_\${PV}_linux-arm64.tar.gz  )  )  "
+                echo "	amd64? ( !extended? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/hugo_\${PV}_linux-amd64.tar.gz -> \${P}-hugo_\${PV}_linux-amd64.tar.gz  )  )  "
+                echo "	amd64? ( extended? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/hugo_extended_\${PV}_Linux-64bit.tar.gz -> \${P}-hugo_extended_\${PV}_Linux-64bit.tar.gz  )  )  "
+                echo "	arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/hugo_\${PV}_linux-arm.tar.gz -> \${P}-hugo_\${PV}_linux-arm.tar.gz  )  "
+                echo "	arm64? ( !extended? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/hugo_\${PV}_linux-arm64.tar.gz -> \${P}-hugo_\${PV}_linux-arm64.tar.gz  )  )  "
+                echo "	arm64? ( extended? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/hugo_extended_\${PV}_linux-arm64.tar.gz -> \${P}-hugo_extended_\${PV}_linux-arm64.tar.gz  )  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="Apache License 2.0"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
                 echo -n ' extended'
-                echo -n ''
-                echo -n ''
-                echo -n ''
+                echo -n ' amd64 arm arm64 extended'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
@@ -136,7 +117,6 @@ jobs:
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
                 echo -n 'extended? ( sys-devel/gcc  ) '
                 echo '"'
                 echo ''
@@ -178,22 +158,48 @@ jobs:
                 echo '    newexe "${{ env.extended_binary_archived_name_arm64 }}" "${{ env.extended_binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/hugo_${version}_linux-amd64.tar.gz" "${{ env.epn }}-${version}-hugo_${version}_linux-amd64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/hugo_extended_${version}_Linux-64bit.tar.gz" "${{ env.epn }}-${version}-hugo_extended_${version}_Linux-64bit.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/hugo_${version}_linux-arm.tar.gz" "${{ env.epn }}-${version}-hugo_${version}_linux-arm.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/hugo_${version}_linux-arm64.tar.gz" "${{ env.epn }}-${version}-hugo_${version}_linux-arm64.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/hugo_extended_${version}_linux-arm64.tar.gz" "${{ env.epn }}-${version}-hugo_extended_${version}_linux-arm64.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/hugo_${version}_linux-amd64.tar.gz" "${{ env.epn }}-${version}-hugo_${version}_linux-amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/hugo_extended_${version}_Linux-64bit.tar.gz" "${{ env.epn }}-${version}-hugo_extended_${version}_Linux-64bit.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/hugo_${version}_linux-arm.tar.gz" "${{ env.epn }}-${version}-hugo_${version}_linux-arm.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/hugo_${version}_linux-arm64.tar.gz" "${{ env.epn }}-${version}-hugo_${version}_linux-arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/hugo_extended_${version}_linux-arm64.tar.gz" "${{ env.epn }}-${version}-hugo_extended_${version}_linux-arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/.github/workflows/www-apps-pagefind-bin-update.yaml
+++ b/.github/workflows/www-apps-pagefind-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.23 Github Binary Release current.config 2026-03-03 10:16:15.640186701 +0000 UTC m=+0.016826779
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
 
 name: www-apps/pagefind-bin update
 
@@ -45,37 +45,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install g2
-        uses: arran4/g2-action@v1.2
-
       - name: Set up Git
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install required tools
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget jq coreutils
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
       - name: Process each release
         id: process_releases
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            cat <<-"EOF" > "$metadata_file"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-          <pkgmetadata>
-            <upstream>
-              <remote-id type="github">CloudCannon/pagefind</remote-id>
-            </upstream>
-          </pkgmetadata>
-          EOF
-          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:CloudCannon/pagefind" --use-add "amd64:Enable amd64" --use-add "arm64:Enable arm64" "$metadata_file"
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
           for tag in $tags; do
             version="${tag#v}"
@@ -100,8 +86,8 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
-            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
-            if [ ! -f "$ebuild_file" ]; then
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+            {
 
               # shellcheck disable=SC2016
               {
@@ -110,28 +96,22 @@ jobs:
                 echo "DESCRIPTION=\"${{ env.description }}\""
                 echo "HOMEPAGE=\"${{ env.homepage }}\""
                 echo 'SRC_URI="'
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/pagefind-${tag}-x86_64-unknown-linux-musl.tar.gz -> \${P}-pagefind-${tag}-x86_64-unknown-linux-musl.tar.gz  )  "
-                echo "  amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/pagefind_extended-${tag}-x86_64-unknown-linux-musl.tar.gz -> \${P}-pagefind_extended-${tag}-x86_64-unknown-linux-musl.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/pagefind-${tag}-aarch64-unknown-linux-musl.tar.gz -> \${P}-pagefind-${tag}-aarch64-unknown-linux-musl.tar.gz  )  "
-                echo "  arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/pagefind_extended-${tag}-aarch64-unknown-linux-musl.tar.gz -> \${P}-pagefind_extended-${tag}-aarch64-unknown-linux-musl.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/pagefind-${tag}-x86_64-unknown-linux-musl.tar.gz -> \${P}-pagefind-${tag}-x86_64-unknown-linux-musl.tar.gz  )  "
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/pagefind_extended-${tag}-x86_64-unknown-linux-musl.tar.gz -> \${P}-pagefind_extended-${tag}-x86_64-unknown-linux-musl.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/pagefind-${tag}-aarch64-unknown-linux-musl.tar.gz -> \${P}-pagefind-${tag}-aarch64-unknown-linux-musl.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v\${PV}/pagefind_extended-${tag}-aarch64-unknown-linux-musl.tar.gz -> \${P}-pagefind_extended-${tag}-aarch64-unknown-linux-musl.tar.gz  )  "
                 echo '"'
-                echo 'LICENSE="MIT"'
+                echo 'LICENSE="MIT License"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ''
-                echo -n ''
-                echo -n ''
-                echo -n ''
+                echo -n ' amd64 arm64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'
-                echo -n ''
                 echo '"'
                 echo ''
                 echo -n 'RDEPEND="'
-                echo -n ''
-                echo -n ''
                 echo '"'
                 echo ''
                 echo 'S="${WORKDIR}"'
@@ -166,21 +146,47 @@ jobs:
                 echo '    newexe "${{ env.extended_binary_archived_name_arm64 }}" "${{ env.extended_binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
                 echo '}'
-              } > $ebuild_file
-
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
               # Manifest generation
-
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/pagefind-${tag}-x86_64-unknown-linux-musl.tar.gz" "${{ env.epn }}-${version}-pagefind-${tag}-x86_64-unknown-linux-musl.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/pagefind_extended-${tag}-x86_64-unknown-linux-musl.tar.gz" "${{ env.epn }}-${version}-pagefind_extended-${tag}-x86_64-unknown-linux-musl.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/pagefind-${tag}-aarch64-unknown-linux-musl.tar.gz" "${{ env.epn }}-${version}-pagefind-${tag}-aarch64-unknown-linux-musl.tar.gz" "${ebuild_dir}/Manifest"
-              g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/pagefind_extended-${tag}-aarch64-unknown-linux-musl.tar.gz" "${{ env.epn }}-${version}-pagefind_extended-${tag}-aarch64-unknown-linux-musl.tar.gz" "${ebuild_dir}/Manifest"
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/pagefind-${tag}-x86_64-unknown-linux-musl.tar.gz" "${{ env.epn }}-${version}-pagefind-${tag}-x86_64-unknown-linux-musl.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/pagefind_extended-${tag}-x86_64-unknown-linux-musl.tar.gz" "${{ env.epn }}-${version}-pagefind_extended-${tag}-x86_64-unknown-linux-musl.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/pagefind-${tag}-aarch64-unknown-linux-musl.tar.gz" "${{ env.epn }}-${version}-pagefind-${tag}-aarch64-unknown-linux-musl.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/pagefind_extended-${tag}-aarch64-unknown-linux-musl.tar.gz" "${{ env.epn }}-${version}-pagefind_extended-${tag}-aarch64-unknown-linux-musl.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
-            fi
           done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
 
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&

--- a/gap.md
+++ b/gap.md
@@ -1,6 +1,0 @@
-# Overlay Workflow Builder Generator Update Gaps
-
-1. **actions/checkout version fallback:** The newly generated workflows are using `actions/checkout@v7` which does not exist and fails workflows. They should use `v4` (or whatever the latest valid tag is).
-2. **Loss of custom environment variables:** The generator removes `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` from the `env:` block.
-3. **Removal of custom Install g2 step:** The generator removes the `Install g2` step using `arran4/g2-action@v1.2` entirely.
-4. **git add metadata/md5-cache/ in workflows:** The generator adds `git add metadata/md5-cache/ || true` to the git commit steps. The cache generation is not enabled by default for everything and memory explicitly says `The repository no longer tracks the metadata/md5-cache or metadata/md5-dict directories in version control.`

--- a/gap.md
+++ b/gap.md
@@ -1,0 +1,6 @@
+# Overlay Workflow Builder Generator Update Gaps
+
+1. **actions/checkout version fallback:** The newly generated workflows are using `actions/checkout@v7` which does not exist and fails workflows. They should use `v4` (or whatever the latest valid tag is).
+2. **Loss of custom environment variables:** The generator removes `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` from the `env:` block.
+3. **Removal of custom Install g2 step:** The generator removes the `Install g2` step using `arran4/g2-action@v1.2` entirely.
+4. **git add metadata/md5-cache/ in workflows:** The generator adds `git add metadata/md5-cache/ || true` to the git commit steps. The cache generation is not enabled by default for everything and memory explicitly says `The repository no longer tracks the metadata/md5-cache or metadata/md5-dict directories in version control.`


### PR DESCRIPTION
- Updates github workflows generated by arrans_overlay_workflow_builder to version `v0.1.28`
- Restores manual adjustments that the generator overrides, like `actions/checkout@v4`, `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`, removing `git add metadata/md5-cache/`.
- Documents gaps and issues in `gap.md`
- Restores manually maintained workflows that were incorrectly overwritten (`dev-util-codex-bin-update.yaml`, `app-misc-gocdm-bin-update.yaml`, `media-sound-go-playerctl-bin-update.yaml`).

---
*PR created automatically by Jules for task [12985957611479210479](https://jules.google.com/task/12985957611479210479) started by @arran4*