### PR TITLE
Update workflows using v0.1.31 and fix regressions

### DIFF
--- a/.github/workflows/app-admin-arrans-overlay-workflow-builder-bin-update.yaml
+++ b/.github/workflows/app-admin-arrans-overlay-workflow-builder-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: app-admin/arrans-overlay-workflow-builder-bin update
 
@@ -80,6 +80,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/app-admin-chezmoi-bin-update.yaml
+++ b/.github/workflows/app-admin-chezmoi-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: app-admin/chezmoi-bin update
 
@@ -104,6 +104,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/app-admin-ejson-bin-update.yaml
+++ b/.github/workflows/app-admin-ejson-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: app-admin/ejson-bin update
 
@@ -82,6 +82,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/app-admin-g2-bin-update.yaml
+++ b/.github/workflows/app-admin-g2-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: app-admin/g2-bin update
 
@@ -84,6 +84,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/app-misc-anytype-to-linkwarden-bin-update.yaml
+++ b/.github/workflows/app-misc-anytype-to-linkwarden-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: app-misc/anytype-to-linkwarden-bin update
 
@@ -82,6 +82,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/app-misc-chatbox-appimage-update.yaml
+++ b/.github/workflows/app-misc-chatbox-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github AppImage Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github AppImage Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: app-misc/chatbox-appimage update
 
@@ -77,6 +77,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/app-misc-dua-cli-bin-update.yaml
+++ b/.github/workflows/app-misc-dua-cli-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: app-misc/dua-cli-bin update
 
@@ -84,6 +84,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/app-misc-flutter-google-datastore-appimage-update.yaml
+++ b/.github/workflows/app-misc-flutter-google-datastore-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github AppImage Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github AppImage Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: app-misc/flutter-google-datastore-appimage update
 
@@ -77,6 +77,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/app-misc-flutter-jules-bin-update.yaml
+++ b/.github/workflows/app-misc-flutter-jules-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: app-misc/flutter-jules-bin update
 
@@ -80,6 +80,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/app-misc-fq-bin-update.yaml
+++ b/.github/workflows/app-misc-fq-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: app-misc/fq-bin update
 
@@ -82,6 +82,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/app-misc-maid-appimage-update.yaml
+++ b/.github/workflows/app-misc-maid-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github AppImage Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github AppImage Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: app-misc/maid-appimage update
 
@@ -72,6 +72,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/app-misc-mvcommon-bin-update.yaml
+++ b/.github/workflows/app-misc-mvcommon-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: app-misc/mvcommon-bin update
 
@@ -82,6 +82,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/app-misc-picocrypt-bin-update.yaml
+++ b/.github/workflows/app-misc-picocrypt-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: app-misc/picocrypt-bin update
 
@@ -75,6 +75,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/app-misc-rntocase-bin-update.yaml
+++ b/.github/workflows/app-misc-rntocase-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: app-misc/rntocase-bin update
 
@@ -148,6 +148,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/app-misc-shineyshot-bin-update.yaml
+++ b/.github/workflows/app-misc-shineyshot-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: app-misc/shineyshot-bin update
 
@@ -86,6 +86,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/app-misc-superfile-bin-update.yaml
+++ b/.github/workflows/app-misc-superfile-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: app-misc/superfile-bin update
 
@@ -83,6 +83,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/app-misc-tuios-bin-update.yaml
+++ b/.github/workflows/app-misc-tuios-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: app-misc/tuios-bin update
 
@@ -86,6 +86,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/app-text-md2png-bin-update.yaml
+++ b/.github/workflows/app-text-md2png-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: app-text/md2png-bin update
 
@@ -84,6 +84,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/app-text-mdsplit-bin-update.yaml
+++ b/.github/workflows/app-text-mdsplit-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: app-text/mdsplit-bin update
 
@@ -82,6 +82,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/app-text-mostcomm-bin-update.yaml
+++ b/.github/workflows/app-text-mostcomm-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: app-text/mostcomm-bin update
 
@@ -84,6 +84,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/dev-go-goreleaser-bin-update.yaml
+++ b/.github/workflows/dev-go-goreleaser-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: dev-go/goreleaser-bin update
 
@@ -88,6 +88,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/dev-util-antigravity-cli-bin-update.yaml
+++ b/.github/workflows/dev-util-antigravity-cli-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: dev-util/antigravity-cli-bin update
 
@@ -82,6 +82,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/dev-util-editorconfig-guesser-bin-update.yaml
+++ b/.github/workflows/dev-util-editorconfig-guesser-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: dev-util/editorconfig-guesser-bin update
 
@@ -84,6 +84,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/dev-util-layerx-bin-update.yaml
+++ b/.github/workflows/dev-util-layerx-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: dev-util/layerx-bin update
 
@@ -82,6 +82,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/dev-vcs-git-credential-oauth-bin-update.yaml
+++ b/.github/workflows/dev-vcs-git-credential-oauth-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: dev-vcs/git-credential-oauth-bin update
 
@@ -84,6 +84,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/dev-vcs-git-tag-inc-bin-update.yaml
+++ b/.github/workflows/dev-vcs-git-tag-inc-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: dev-vcs/git-tag-inc-bin update
 
@@ -84,6 +84,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/net-im-caprine-appimage-update.yaml
+++ b/.github/workflows/net-im-caprine-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github AppImage Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github AppImage Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: net-im/caprine-appimage update
 
@@ -76,6 +76,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/net-im-lemmy-notify-appimage-update.yaml
+++ b/.github/workflows/net-im-lemmy-notify-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github AppImage Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github AppImage Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: net-im/lemmy-notify-appimage update
 
@@ -76,6 +76,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/net-im-slackdump-bin-update.yaml
+++ b/.github/workflows/net-im-slackdump-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: net-im/slackdump-bin update
 
@@ -85,6 +85,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/net-misc-abc-justin-rss-bin-update.yaml
+++ b/.github/workflows/net-misc-abc-justin-rss-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: net-misc/abc-justin-rss-bin update
 
@@ -84,6 +84,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/net-misc-localsend-appimage-update.yaml
+++ b/.github/workflows/net-misc-localsend-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github AppImage Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github AppImage Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: net-misc/localsend-appimage update
 
@@ -76,6 +76,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/net-misc-pimtrace-bin-update.yaml
+++ b/.github/workflows/net-misc-pimtrace-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: net-misc/pimtrace-bin update
 
@@ -82,6 +82,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/net-misc-podcast-cdr-manager-bin-update.yaml
+++ b/.github/workflows/net-misc-podcast-cdr-manager-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: net-misc/podcast-cdr-manager-bin update
 
@@ -84,6 +84,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/net-misc-reddit-tui-bin-update.yaml
+++ b/.github/workflows/net-misc-reddit-tui-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: net-misc/reddit-tui-bin update
 
@@ -82,6 +82,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/net-misc-rustdesk-appimage-update.yaml
+++ b/.github/workflows/net-misc-rustdesk-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github AppImage Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github AppImage Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: net-misc/rustdesk-appimage update
 
@@ -74,6 +74,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/sys-apps-lxa-bin-update.yaml
+++ b/.github/workflows/sys-apps-lxa-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: sys-apps/lxa-bin update
 
@@ -82,6 +82,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/www-apps-hugo-bin-update.yaml
+++ b/.github/workflows/www-apps-hugo-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: www-apps/hugo-bin update
 
@@ -89,6 +89,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/.github/workflows/www-apps-pagefind-bin-update.yaml
+++ b/.github/workflows/www-apps-pagefind-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.28 Github Binary Release current.config 2026-07-29 10:12:51.534267815 +0000 UTC m=+0.005924636
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.31 Github Binary Release current.config 2026-07-30 09:04:19.177157275 +0000 UTC m=+0.006149846
 
 name: www-apps/pagefind-bin update
 
@@ -87,6 +87,7 @@ jobs:
                 continue
             fi
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
               # shellcheck disable=SC2016
               {
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'

--- a/gap.md
+++ b/gap.md
@@ -1,0 +1,12 @@
+# Feedback and Feature Requests for overlay_workflow_builder_generator v0.1.31
+
+I have encountered a few issues while using version 0.1.31 of `overlay_workflow_builder_generator` and I wanted to file these feature requests/issues to help improve the tool.
+
+## Issues with generated `.github/workflows/*-update.yaml` workflows
+1.  **Missing `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`**: The generator no longer outputs the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` environment variable in the generated workflows, which was present in previously generated files (e.g. from version 0.1.28). This causes issues with certain runners.
+2.  **Invalid `actions/checkout` version**: The generated workflows use `uses: actions/checkout@v7`, which is an invalid version of the action (the latest major version is `v4`). It should use `uses: actions/checkout@v4` instead.
+3.  **Invalid `g2 ebuild next-revision` syntax**: The generator changed the `g2 ebuild next-revision` command call. It used to be `g2 ebuild next-revision --inspect "$tmp_ebuild_file" "${ebuild_dir}" "${version}"` which outputs the `next_version` (e.g., `-r1`). It was changed to `g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file"` which assigns to `next_ebuild_file` directly. This change uses an invalid flag structure.
+4.  **Global `lint .`**: The linting step was changed from `action: 'lint ${{ env.ecn }}/${{ env.epn }}'` to `action: 'lint . ${{ env.ecn }}/${{ env.epn }}'`. Running a global lint (`lint .`) on every update workflow may take too long or trigger errors on unrelated packages. Furthermore, the `if: steps.process_releases.outputs.generated_tag` condition was removed.
+5.  **`metadata/md5-cache/` tracking**: The generator adds `git add metadata/md5-cache/ || true` to the commit step. Since `metadata/md5-cache` is no longer tracked in version control, this line is incorrect and can lead to unexpected behavior.
+
+Would it be possible to address these regressions in a future version of `overlay_workflow_builder_generator`?


### PR DESCRIPTION
Regenerated workflows using the new version of `overlay_workflow_builder_generator` (v0.1.31). I have reverted the bad changes that broke custom logic (such as missing `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`, the checkout version regression to `v7`, invalid `g2 ebuild next-revision` syntax, incorrect `lint` targets, and errant `git add` for cache). These issues have been thoroughly documented in a `gap.md` report.

---
*PR created automatically by Jules for task [7939684055845067705](https://jules.google.com/task/7939684055845067705) started by @arran4*