### PR TITLE
ci: run g2 manifest clean in daily tasks

### DIFF
--- a/.github/workflows/scheduled-daily-tasks.yml
+++ b/.github/workflows/scheduled-daily-tasks.yml
@@ -52,6 +52,11 @@ jobs:
           ref: main
           fetch-depth: 0
 
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+        with:
+          version: ${{ inputs.g2_version || 'latest' }}
+
       - name: Configure Overlay
         run: |
           mkdir -p /etc/portage/repos.conf
@@ -71,6 +76,11 @@ jobs:
           echo "$OUTPUT" >> $GITHUB_ENV
           echo "INNER_EOF" >> $GITHUB_ENV
           echo "$OUTPUT"
+
+      - name: Clean manifests
+        continue-on-error: true
+        run: |
+          g2 manifest clean .
 
       - name: Run egencache update
         id: egencache


### PR DESCRIPTION
This PR updates the daily tasks workflow to include a global `g2 manifest clean .` step as per user request to clean up all manifests in the repository, leveraging the newly installed `g2` tool version.

---
*PR created automatically by Jules for task [8186018966535941733](https://jules.google.com/task/8186018966535941733) started by @arran4*