### PR TITLE
ci: ignore g2 lint md5-cache warnings with wrapper script

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -59,5 +59,5 @@ jobs:
             echo "No package files changed. Skipping lint."
           else
             echo "Running g2 lint on changed directories: $DIRS"
-            g2 lint $DIRS
+            ./scripts/g2-lint-wrapper.sh $DIRS
           fi

--- a/gap.md
+++ b/gap.md
@@ -1,0 +1,16 @@
+## Missing g2 qa-policy.conf support for ignoring rules
+
+The `g2 lint` tool currently has hardcoded behavior for checking MD5 Cache missing (`PG0802`). The `lints/md5cache/md5cache_missing.go` ignores `ignore` values from `metadata/qa-policy.conf` and only allows changing severity to `notice`, `error`, or `warning`:
+
+```go
+		if val, ok := qa.Policies["PG0802"]; ok {
+			if val == "notice" || val == "error" || val == "warning" {
+                // ... sets severity
+			}
+            // If val == "ignore", it does nothing, severity stays warning!
+		}
+```
+
+This prevents completely ignoring a rule via policy. It should allow returning early or omitting results if `val == "ignore"`.
+
+As a workaround for `arrans_overlay`, since md5-cache is completely disabled/removed, I have updated `.github/workflows/pr-checks.yml` to use a custom bash wrapper `scripts/g2-lint-wrapper.sh` that filters out the warning and handles the exit code correctly.

--- a/scripts/g2-lint-wrapper.sh
+++ b/scripts/g2-lint-wrapper.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+OUTPUT=$(g2 lint "$@" 2>&1 || true)
+FILTERED=$(echo "$OUTPUT" | grep -v '\[Warning\] Missing md5-cache for ebuild' | grep -v 'linting found errors' || true)
+
+FILTERED=$(echo "$FILTERED" | awk '
+/^\[.*\]$/ {
+  if (header != "" && content == 1) {
+    print header
+    print buffer
+  }
+  header = $0
+  buffer = ""
+  content = 0
+  next
+}
+{
+  if (header != "") {
+    if (buffer != "") {
+       buffer = buffer "\n" $0
+    } else {
+       buffer = $0
+    }
+    if ($0 ~ /[^[:space:]]/) {
+        content = 1
+    }
+  } else {
+    print $0
+  }
+}
+END {
+  if (header != "" && content == 1) {
+    print header
+    print buffer
+  }
+}
+')
+
+echo "$FILTERED"
+if [ -n "$FILTERED" ] && echo "$FILTERED" | grep -q '\[\(Error\|Warning\)\]'; then
+    false
+else
+    true
+fi


### PR DESCRIPTION
Introduced `scripts/g2-lint-wrapper.sh` to wrap `g2 lint` and filter out missing md5-cache warnings (`PG0802`) since upstream `g2` does not correctly handle `ignore` in `qa-policy.conf`. Updated `.github/workflows/pr-checks.yml` to use the wrapper. Documented the gap in `gap.md`.

---
*PR created automatically by Jules for task [9917654471962300313](https://jules.google.com/task/9917654471962300313) started by @arran4*