### PR TITLE
Add lxd-ui ebuild configuration and update workflow

### DIFF
--- a/.github/workflows/app-admin-lxd-ui-bin-update.yaml
+++ b/.github/workflows/app-admin-lxd-ui-bin-update.yaml
@@ -1,0 +1,174 @@
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.35 Github Binary Release current.config 2026-08-04 02:14:48.533778274 +0000 UTC m=+0.007541276
+
+name: app-admin/lxd-ui-bin update
+
+permissions:
+  contents: write
+
+on:
+  schedule:
+    - cron: '55 9 * * *'
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/app-admin-lxd-ui-bin-update.yaml'
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  ecn: app-admin
+  epn: lxd-ui-bin
+  description: "A browser frontend for LXD. Enables easy and accessible container and virtual machine management."
+  homepage: "https://github.com/canonical/lxd-ui"
+  github_owner: canonical
+  github_repo: lxd-ui
+  keywords: ~amd64 ~arm64
+  workflow_filename: app-admin-lxd-ui-bin-update.yaml
+  lxd-ui_binary_installed_name: 'lxd-ui'
+  lxd-ui_binary_archived_name_amd64: 'lxd-ui'
+  lxd-ui_release_name_amd64: 'lxd-ui-linux-amd64-${version}.tar.gz'
+  lxd-ui_binary_archived_name_arm64: 'lxd-ui'
+  lxd-ui_release_name_arm64: 'lxd-ui-linux-arm64-${version}.tar.gz'
+
+jobs:
+  check-and-create-ebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
+      - name: Process each release
+        id: process_releases
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p "$ebuild_dir"
+          metadata_file="${ebuild_dir}/metadata.xml"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:canonical/lxd-ui" --use-add "amd64:Enable amd64" --use-add "arm64:Enable arm64" "$metadata_file"
+          declare -A releaseTypes=()
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          # shellcheck disable=SC2086
+          for tag in $tags; do
+            version="${tag#v}"
+            if [ "${version}" = "${tag}" ]; then
+                echo "$version == $tag so there is no v removed skipping"
+                continue
+            fi
+            # shellcheck disable=SC2034
+            originalVersion="${version}"
+            if ! echo "${version}" | grep -E '^([0-9]+)\.([0-9]+)(\.([0-9]+))?(-r[0-9]+)?((_)(alpha|beta|rc|p)[0-9]*)*$'; then
+                echo "tag / $version doesn't match regexp";
+                continue;
+            fi
+            releaseType="$(echo "${version}" | sed -n 's/^[^_]\+_\(alpha\|beta\|rc\|p[0-9]*\).*$/\1/p')"
+            if [[ ! -v releaseTypes[${releaseType:=release}] ]]; then
+                if [[ -v releaseTypes[release] ]]; then
+                  echo "Already have a newer main release: ${releaseTypes[release]}"
+                  continue
+                fi
+                releaseTypes[${releaseType:=release}]="${version}"
+            else
+                echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
+                continue
+            fi
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
+              # shellcheck disable=SC2016
+              {
+                echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
+                echo 'EAPI=8'
+                echo "DESCRIPTION=\"${{ env.description }}\""
+                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'SRC_URI="'
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v${originalVersion}/lxd-ui-linux-amd64-\${PV}.tar.gz -> \${P}-lxd-ui-linux-amd64-\${PV}.tar.gz  )  "
+                echo "	arm64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v${originalVersion}/lxd-ui-linux-arm64-\${PV}.tar.gz -> \${P}-lxd-ui-linux-arm64-\${PV}.tar.gz  )  "
+                echo '"'
+                echo 'LICENSE="GPL-3.0"'
+                echo 'SLOT="0"'
+                echo 'KEYWORDS="${{ env.keywords }}"'
+                echo -n 'IUSE="'
+                echo -n ' amd64 arm64'
+                echo '"'
+                echo ''
+                echo -n 'REQUIRED_USE="'
+                echo '"'
+                echo ''
+                echo -n 'RDEPEND="'
+                echo '"'
+                echo ''
+                echo 'S="${WORKDIR}"'
+                echo ''
+                echo 'src_unpack() {'
+                echo '  if use amd64; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-lxd-ui-linux-amd64-\${PV}.tar.gz\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '  if use arm64; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-lxd-ui-linux-arm64-\${PV}.tar.gz\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '}'
+                echo ''
+                echo 'src_install() {'
+                echo '  exeinto /opt/bin'
+                echo '  if use amd64; then'
+                echo '    newexe "${{ env.lxd-ui_binary_archived_name_amd64 }}" "${{ env.lxd-ui_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '  if use arm64; then'
+                echo '    newexe "${{ env.lxd-ui_binary_archived_name_arm64 }}" "${{ env.lxd-ui_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '}'
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
+              # Manifest generation
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/lxd-ui-linux-amd64-${version}.tar.gz" "${{ env.epn }}-${version}-lxd-ui-linux-amd64-${version}.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/lxd-ui-linux-arm64-${version}.tar.gz" "${{ env.epn }}-${version}-lxd-ui-linux-arm64-${version}.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
+              echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
+          done
+          g2 ebuild deduplicate "${ebuild_dir}"
+          g2 manifest clean "${ebuild_dir}"
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint . ${{ env.ecn }}/${{ env.epn }}'
+
+      - name: Commit and push changes
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
+          git add "./${ebuild_dir}"
+          if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
+            git pull --rebase &&
+            git push
+          fi || true
+        if: steps.process_releases.outputs.generated_tag

--- a/current.config
+++ b/current.config
@@ -681,3 +681,15 @@ License Apache-2.0
 ProgramName antigravity
 Binary amd64=>agy_cli_linux_x64.tar.gz > antigravity > antigravity
 Binary arm64=>agy_cli_linux_arm64.tar.gz > antigravity > antigravity
+
+
+Type Github Binary Release
+GithubProjectUrl https://github.com/canonical/lxd-ui
+Category app-admin
+EbuildName lxd-ui-bin.ebuild
+Description A browser frontend for LXD. Enables easy and accessible container and virtual machine management.
+Homepage https://github.com/canonical/lxd-ui
+License GPL-3.0
+ProgramName lxd-ui
+Binary amd64=>lxd-ui-linux-amd64-${VERSION}.tar.gz > lxd-ui > lxd-ui
+Binary arm64=>lxd-ui-linux-arm64-${VERSION}.tar.gz > lxd-ui > lxd-ui


### PR DESCRIPTION
Add a new `Github Binary Release` entry for `lxd-ui` to `current.config` and correctly generate the GitHub Actions workflow to auto-update the ebuild and manifest.
Used the latest major version for checkout (`v4`) according to the user's instructions.
Corrected the asset URLs inside the workflow and the generated ebuild to match the upstream tarballs.

---
*PR created automatically by Jules for task [450464564068590609](https://jules.google.com/task/450464564068590609) started by @arran4*