### PR TITLE
fix: bypass g2 lint warning for missing md5-cache in workflows

### DIFF
--- a/.github/workflows/app-admin-arrans-overlay-workflow-builder-bin-update.yaml
+++ b/.github/workflows/app-admin-arrans-overlay-workflow-builder-bin-update.yaml
@@ -151,10 +151,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/app-admin-chezmoi-bin-update.yaml
+++ b/.github/workflows/app-admin-chezmoi-bin-update.yaml
@@ -254,10 +254,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/app-admin-ejson-bin-update.yaml
+++ b/.github/workflows/app-admin-ejson-bin-update.yaml
@@ -163,10 +163,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/app-admin-g2-bin-update.yaml
+++ b/.github/workflows/app-admin-g2-bin-update.yaml
@@ -167,10 +167,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/app-misc-anytype-to-linkwarden-bin-update.yaml
+++ b/.github/workflows/app-misc-anytype-to-linkwarden-bin-update.yaml
@@ -167,10 +167,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/app-misc-chatbox-appimage-update.yaml
+++ b/.github/workflows/app-misc-chatbox-appimage-update.yaml
@@ -167,10 +167,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/app-misc-dua-cli-bin-update.yaml
+++ b/.github/workflows/app-misc-dua-cli-bin-update.yaml
@@ -186,10 +186,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/app-misc-flutter-google-datastore-appimage-update.yaml
+++ b/.github/workflows/app-misc-flutter-google-datastore-appimage-update.yaml
@@ -162,10 +162,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/app-misc-flutter-jules-bin-update.yaml
+++ b/.github/workflows/app-misc-flutter-jules-bin-update.yaml
@@ -148,10 +148,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/app-misc-fq-bin-update.yaml
+++ b/.github/workflows/app-misc-fq-bin-update.yaml
@@ -157,10 +157,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/app-misc-maid-appimage-update.yaml
+++ b/.github/workflows/app-misc-maid-appimage-update.yaml
@@ -152,10 +152,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/app-misc-mvcommon-bin-update.yaml
+++ b/.github/workflows/app-misc-mvcommon-bin-update.yaml
@@ -162,10 +162,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/app-misc-picocrypt-bin-update.yaml
+++ b/.github/workflows/app-misc-picocrypt-bin-update.yaml
@@ -139,10 +139,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/app-misc-rntocase-bin-update.yaml
+++ b/.github/workflows/app-misc-rntocase-bin-update.yaml
@@ -308,10 +308,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/app-misc-shineyshot-bin-update.yaml
+++ b/.github/workflows/app-misc-shineyshot-bin-update.yaml
@@ -193,10 +193,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/app-misc-superfile-bin-update.yaml
+++ b/.github/workflows/app-misc-superfile-bin-update.yaml
@@ -158,10 +158,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/app-misc-tuios-bin-update.yaml
+++ b/.github/workflows/app-misc-tuios-bin-update.yaml
@@ -182,10 +182,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/app-text-md2png-bin-update.yaml
+++ b/.github/workflows/app-text-md2png-bin-update.yaml
@@ -167,10 +167,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/app-text-mdsplit-bin-update.yaml
+++ b/.github/workflows/app-text-mdsplit-bin-update.yaml
@@ -157,10 +157,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/app-text-mostcomm-bin-update.yaml
+++ b/.github/workflows/app-text-mostcomm-bin-update.yaml
@@ -184,10 +184,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/dev-go-goreleaser-bin-update.yaml
+++ b/.github/workflows/dev-go-goreleaser-bin-update.yaml
@@ -212,10 +212,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/dev-util-antigravity-cli-bin-update.yaml
+++ b/.github/workflows/dev-util-antigravity-cli-bin-update.yaml
@@ -157,10 +157,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/dev-util-editorconfig-guesser-bin-update.yaml
+++ b/.github/workflows/dev-util-editorconfig-guesser-bin-update.yaml
@@ -184,10 +184,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/dev-util-layerx-bin-update.yaml
+++ b/.github/workflows/dev-util-layerx-bin-update.yaml
@@ -157,10 +157,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/dev-vcs-git-credential-oauth-bin-update.yaml
+++ b/.github/workflows/dev-vcs-git-credential-oauth-bin-update.yaml
@@ -173,10 +173,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/dev-vcs-git-tag-inc-bin-update.yaml
+++ b/.github/workflows/dev-vcs-git-tag-inc-bin-update.yaml
@@ -180,10 +180,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/net-im-caprine-appimage-update.yaml
+++ b/.github/workflows/net-im-caprine-appimage-update.yaml
@@ -161,10 +161,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/net-im-lemmy-notify-appimage-update.yaml
+++ b/.github/workflows/net-im-lemmy-notify-appimage-update.yaml
@@ -161,10 +161,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/net-im-slackdump-bin-update.yaml
+++ b/.github/workflows/net-im-slackdump-bin-update.yaml
@@ -168,10 +168,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/net-misc-abc-justin-rss-bin-update.yaml
+++ b/.github/workflows/net-misc-abc-justin-rss-bin-update.yaml
@@ -172,10 +172,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/net-misc-localsend-appimage-update.yaml
+++ b/.github/workflows/net-misc-localsend-appimage-update.yaml
@@ -161,10 +161,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/net-misc-pimtrace-bin-update.yaml
+++ b/.github/workflows/net-misc-pimtrace-bin-update.yaml
@@ -166,10 +166,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/net-misc-podcast-cdr-manager-bin-update.yaml
+++ b/.github/workflows/net-misc-podcast-cdr-manager-bin-update.yaml
@@ -171,10 +171,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/net-misc-reddit-tui-bin-update.yaml
+++ b/.github/workflows/net-misc-reddit-tui-bin-update.yaml
@@ -164,10 +164,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/net-misc-rustdesk-appimage-update.yaml
+++ b/.github/workflows/net-misc-rustdesk-appimage-update.yaml
@@ -161,10 +161,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -59,5 +59,16 @@ jobs:
             echo "No package files changed. Skipping lint."
           else
             echo "Running g2 lint on changed directories: $DIRS"
-            g2 lint $DIRS
+            set +e
+            g2 lint $DIRS > lint.log 2>&1
+            EXIT_CODE=$?
+            set -e
+
+            if [ $EXIT_CODE -ne 0 ]; then
+              if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+                cat lint.log
+                exit $EXIT_CODE
+              fi
+            fi
+            cat lint.log
           fi

--- a/.github/workflows/sys-apps-lxa-bin-update.yaml
+++ b/.github/workflows/sys-apps-lxa-bin-update.yaml
@@ -161,10 +161,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/www-apps-hugo-bin-update.yaml
+++ b/.github/workflows/www-apps-hugo-bin-update.yaml
@@ -191,10 +191,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes

--- a/.github/workflows/www-apps-pagefind-bin-update.yaml
+++ b/.github/workflows/www-apps-pagefind-bin-update.yaml
@@ -178,10 +178,19 @@ jobs:
           echo "8" > profiles/eapi
 
       - name: Lint output
-        uses: arran4/g2-action@v1.2
-        with:
-          mode: 'run'
-          action: 'lint ${{ env.ecn }}/${{ env.epn }}'
+        run: |
+          set +e
+          g2 lint ${{ env.ecn }}/${{ env.epn }} > lint.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            if grep -E '\[Warning\]|\[Error\]' lint.log | grep -vq 'Missing md5-cache' || ! grep -q -E '\[Warning\]|\[Error\]' lint.log; then
+              cat lint.log
+              exit $EXIT_CODE
+            fi
+          fi
+          cat lint.log
         if: steps.process_releases.outputs.generated_tag
 
       - name: Commit and push changes


### PR DESCRIPTION
Fixes the issue where `g2 lint` was failing CI due to 'Missing md5-cache' warnings despite successful ebuild validation.

---
*PR created automatically by Jules for task [7294681236583981697](https://jules.google.com/task/7294681236583981697) started by @arran4*