### PR TITLE
feat: add denial window manager to current.config

### DIFF
--- a/.github/workflows/x11-wm-denial-bin-update.yaml
+++ b/.github/workflows/x11-wm-denial-bin-update.yaml
@@ -117,8 +117,9 @@ jobs:
                 echo '  fi'
                 echo '}'
               } > "$tmp_ebuild_file"
-              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              next_version=$(g2 ebuild next-revision --inspect "$tmp_ebuild_file" "${ebuild_dir}" "${version}")
               if [ $? -eq 0 ]; then
+                  next_ebuild_file="${ebuild_dir}/${{ env.epn }}-${next_version}.ebuild"
                   echo "Content changed or new version for $version. Writing $next_ebuild_file"
                   mv "$tmp_ebuild_file" "$next_ebuild_file"
                   ebuild_file="$next_ebuild_file"

--- a/.github/workflows/x11-wm-denial-bin-update.yaml
+++ b/.github/workflows/x11-wm-denial-bin-update.yaml
@@ -1,0 +1,163 @@
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.36 Github Binary Release current.config 2026-08-06 07:41:39.149865432 +0000 UTC m=+0.006020064
+
+name: x11-wm/denial-bin update
+
+permissions:
+  contents: write
+
+on:
+  schedule:
+    - cron: '21 10 * * *'
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/x11-wm-denial-bin-update.yaml'
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  ecn: x11-wm
+  epn: denial-bin
+  description: "A secure and minimalist tiling window manager for Wayland"
+  homepage: "https://denialwm.org/"
+  github_owner: denialwm
+  github_repo: denial
+  keywords: ~amd64
+  workflow_filename: x11-wm-denial-bin-update.yaml
+  denial_binary_installed_name: 'deniald'
+  denial_binary_archived_name_amd64: 'usr/bin/denial-session'
+  denial_release_name_amd64: 'denial-${tag}-1-x86_64.pkg.tar.zst'
+
+jobs:
+  check-and-create-ebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
+      - name: Process each release
+        id: process_releases
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p "$ebuild_dir"
+          metadata_file="${ebuild_dir}/metadata.xml"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:denialwm/denial" --use-add "amd64:Enable amd64" "$metadata_file"
+          declare -A releaseTypes=()
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          # shellcheck disable=SC2086
+          for tag in $tags; do
+            version="${tag#v}"
+            if [ "${version}" = "${tag}" ]; then
+                echo "$version == $tag so there is no v removed skipping"
+                continue
+            fi
+            # shellcheck disable=SC2034
+            originalVersion="${version}"
+            if ! echo "${version}" | grep -E '^([0-9]+)\.([0-9]+)(\.([0-9]+))?(-r[0-9]+)?((_)(alpha|beta|rc|p)[0-9]*)*$'; then
+                echo "tag / $version doesn't match regexp";
+                continue;
+            fi
+            releaseType="$(echo "${version}" | sed -n 's/^[^_]\+_\(alpha\|beta\|rc\|p[0-9]*\).*$/\1/p')"
+            if [[ ! -v releaseTypes[${releaseType:=release}] ]]; then
+                if [[ -v releaseTypes[release] ]]; then
+                  echo "Already have a newer main release: ${releaseTypes[release]}"
+                  continue
+                fi
+                releaseTypes[${releaseType:=release}]="${version}"
+            else
+                echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
+                continue
+            fi
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
+              # shellcheck disable=SC2016
+              {
+                echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
+                echo 'EAPI=8'
+                echo "DESCRIPTION=\"${{ env.description }}\""
+                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'SRC_URI="'
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/\${PV} -> \${P}-denial-${tag}-1-x86_64.pkg.tar.zst  )  "
+                echo '"'
+                echo 'LICENSE="MIT License"'
+                echo 'SLOT="0"'
+                echo 'KEYWORDS="${{ env.keywords }}"'
+                echo -n 'IUSE="'
+                echo -n ' amd64'
+                echo '"'
+                echo ''
+                echo -n 'REQUIRED_USE="'
+                echo '"'
+                echo ''
+                echo -n 'RDEPEND="'
+                echo '"'
+                echo ''
+                echo 'S="${WORKDIR}"'
+                echo ''
+                echo 'src_unpack() {'
+                echo '  if use amd64; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-denial-${tag}-1-x86_64.pkg.tar.zst\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '}'
+                echo ''
+                echo 'src_install() {'
+                echo '  exeinto /opt/bin'
+                echo '  if use amd64; then'
+                echo '    newexe "${{ env.denial_binary_archived_name_amd64 }}" "${{ env.denial_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '}'
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
+              # Manifest generation
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/${version}" "${{ env.epn }}-${version}-denial-${tag}-1-x86_64.pkg.tar.zst" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
+              echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
+          done
+          g2 ebuild deduplicate "${ebuild_dir}"
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint . ${{ env.ecn }}/${{ env.epn }}'
+
+      - name: Commit and push changes
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
+          git add "./${ebuild_dir}"
+          if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
+            git pull --rebase &&
+            git push
+          fi || true
+        if: steps.process_releases.outputs.generated_tag

--- a/current.config
+++ b/current.config
@@ -681,3 +681,15 @@ License Apache-2.0
 ProgramName antigravity
 Binary amd64=>agy_cli_linux_x64.tar.gz > antigravity > antigravity
 Binary arm64=>agy_cli_linux_arm64.tar.gz > antigravity > antigravity
+
+Type Github Binary Release
+GithubProjectUrl https://github.com/denialwm/denial
+Category x11-wm
+EbuildName denial-bin.ebuild
+Description A secure and minimalist tiling window manager for Wayland
+Homepage https://denialwm.org/
+License MIT License
+ProgramName denial
+Binary amd64=>denial-${TAG}-1-x86_64.pkg.tar.zst > usr/bin/denial-session > denial-session
+Binary amd64=>denial-${TAG}-1-x86_64.pkg.tar.zst > usr/bin/denialctl > denialctl
+Binary amd64=>denial-${TAG}-1-x86_64.pkg.tar.zst > usr/bin/deniald > deniald


### PR DESCRIPTION
This PR adds a new package configuration in `current.config` for the `denial` Wayland tiling window manager, sourcing its release from `https://github.com/denialwm/denial`. The `overlay_workflow_builder_generator` tool was executed to generate the corresponding automated ebuild GitHub Action workflow for the package (`x11-wm-denial-bin-update.yaml`).

The upstream binaries (`deniald`, `denialctl`, `denial-session`) are explicitly specified in the configuration for proper extraction from the `pkg.tar.zst` release archive.

`verify_manifest.py` passed successfully after generation.

---
*PR created automatically by Jules for task [18088532841915293097](https://jules.google.com/task/18088532841915293097) started by @arran4*