### PR TITLE
chore: update scheduled-daily-tasks cron to 17:00 UTC

### DIFF
--- a/.github/workflows/scheduled-daily-tasks.yml
+++ b/.github/workflows/scheduled-daily-tasks.yml
@@ -8,7 +8,7 @@ permissions:
 
 on:
   schedule:
-    - cron: '0 19 * * *'
+    - cron: '0 17 * * *'
   workflow_dispatch:
     inputs:
       g2_version:


### PR DESCRIPTION
Update the `scheduled-daily-tasks` cron schedule in `.github/workflows/scheduled-daily-tasks.yml` to run at `0 17 * * *` as explicitly requested by the user.

---
*PR created automatically by Jules for task [4411936596388824032](https://jules.google.com/task/4411936596388824032) started by @arran4*