### PR TITLE
fix: update news date to match git

### DIFF
--- a/metadata/news/2024-07-22-flatpak-migration/2024-07-22-flatpak-migration.en.txt
+++ b/metadata/news/2024-07-22-flatpak-migration/2024-07-22-flatpak-migration.en.txt
@@ -1,7 +1,7 @@
 Title: Migration to Flatpak for several applications
 Author: Arran <gentoo@arran4.com>
 Author: Jules <gentoo@arran4.com>
-Posted: 2024-07-22
+Posted: 2026-07-22
 Revision: 1
 News-Item-Format: 2.0
 Display-If-Installed: app-text/anytype-ts-appimage


### PR DESCRIPTION
As requested, updated the hardcoded date in the `2024-07-22-flatpak-migration` news text file to match the actual `git` commit timestamp when the file was introduced (`2026-07-22` per commit `c3eadcf4ced43a61e8ced043f0ddb1c090f305eb`).

---
*PR created automatically by Jules for task [1272513267631142600](https://jules.google.com/task/1272513267631142600) started by @arran4*