### PR TITLE
Disable md5 cache format generation

### DIFF
--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -1,3 +1,4 @@
 masters = gentoo
 thin-manifests = true
 sign-manifests = false
+cache-formats =


### PR DESCRIPTION
Configure repo to disable md5 cache format generation

Update metadata/layout.conf to explicitly set `cache-formats = ` empty. This disables the expected generation and tracking of md5-cache for the overlay.

---
*PR created automatically by Jules for task [147431598197176538](https://jules.google.com/task/147431598197176538) started by @arran4*