### PR TITLE
Set layout.conf cache-formats explicitly to md5-dict

### DIFF
--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -1,4 +1,4 @@
 masters = gentoo
 thin-manifests = true
 sign-manifests = false
-cache-formats =
+cache-formats = md5-dict


### PR DESCRIPTION
The previous pull request (#765) disabled md5 cache generation by setting `cache-formats = ` (empty). This PR restores cache format generation by being explicit about the required format, setting it to `cache-formats = md5-dict`.

---
*PR created automatically by Jules for task [4968957211260453851](https://jules.google.com/task/4968957211260453851) started by @arran4*