### PR TITLE
Fix malformed patch in dev-libs/lvgl

### DIFF
--- a/dev-libs/lvgl/files/lvgl-9.5.0-pkgconfig.patch
+++ b/dev-libs/lvgl/files/lvgl-9.5.0-pkgconfig.patch
@@ -1,6 +1,6 @@
 --- a/lvgl.pc.in
 +++ b/lvgl.pc.in
-@@ -1,10 +1,12 @@
+@@ -1,10 +1,11 @@
  prefix="@CMAKE_INSTALL_PREFIX@"
  includedir="${prefix}/@INC_INSTALL_DIR@"
 -libdir=${prefix}/lib


### PR DESCRIPTION
Fixes an emerge build failure for `dev-libs/lvgl-9.5.0`, which was failing in the `src_prepare` phase due to a `gpatch: **** malformed patch at line 17` error when applying `lvgl-9.5.0-pkgconfig.patch`.

* Fixed incorrect hunk header line count (`@@ -1,10 +1,12 @@` -> `@@ -1,10 +1,11 @@`).
* Added missing space to the empty context line.
* Tested that the patch now applies cleanly without errors.

---
*PR created automatically by Jules for task [8834702459328480176](https://jules.google.com/task/8834702459328480176) started by @arran4*