### PR TITLE
dev-libs/lvgl: fix CMake QA Notice for minimum required version

### DIFF
--- a/dev-libs/lvgl/files/lvgl-9.5.0-cmake-qa-notice.patch
+++ b/dev-libs/lvgl/files/lvgl-9.5.0-cmake-qa-notice.patch
@@ -1,0 +1,8 @@
+--- a/env_support/esp/rlottie/CMakeLists.txt
++++ b/env_support/esp/rlottie/CMakeLists.txt
+@@ -1,5 +1,5 @@
+-cmake_minimum_required(VERSION 3.5)
++cmake_minimum_required(VERSION 3.10)
+
+ if (0)
+ if (LV_USE_RLOTTIE)

--- a/dev-libs/lvgl/lvgl-9.5.0.ebuild
+++ b/dev-libs/lvgl/lvgl-9.5.0.ebuild
@@ -26,6 +26,9 @@ PATCHES=(
 )
 
 src_prepare() {
+	# Fix CMake QA Notice for < 3.10
+	sed -i -e 's/cmake_minimum_required(VERSION 3.5)/cmake_minimum_required(VERSION 3.10)/' "${S}/env_support/esp/rlottie/CMakeLists.txt" || die
+
 	cmake_src_prepare
 
 	cp "${S}/lv_conf_template.h" "${S}/lv_conf.h" || die

--- a/dev-libs/lvgl/lvgl-9.5.0.ebuild
+++ b/dev-libs/lvgl/lvgl-9.5.0.ebuild
@@ -23,12 +23,10 @@ DEPEND="${RDEPEND}"
 
 PATCHES=(
 	"${FILESDIR}/${P}-pkgconfig.patch"
+	"${FILESDIR}/${P}-cmake-qa-notice.patch"
 )
 
 src_prepare() {
-	# Fix CMake QA Notice for < 3.10
-	sed -i -e 's/cmake_minimum_required(VERSION 3.5)/cmake_minimum_required(VERSION 3.10)/' "${S}/env_support/esp/rlottie/CMakeLists.txt" || die
-
 	cmake_src_prepare
 
 	cp "${S}/lv_conf_template.h" "${S}/lv_conf.h" || die


### PR DESCRIPTION
Moved the sed command in dev-libs/lvgl/lvgl-9.5.0.ebuild to run before cmake_src_prepare. This ensures that the QA notice complaining about deprecated cmake_minimum_required(VERSION 3.5) is suppressed, as the eclass checks for this during cmake_src_prepare.

---
*PR created automatically by Jules for task [11515875705917613442](https://jules.google.com/task/11515875705917613442) started by @arran4*