### PR TITLE
chore: restore cache generation

### DIFF
--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -1,4 +1,4 @@
 masters = gentoo
 thin-manifests = true
 sign-manifests = false
-cache-formats =
+cache-formats = md5-dict


### PR DESCRIPTION
The user noticed cache generation was disabled and requested that it be turned back on. This PR sets cache-formats to md5-dict in metadata/layout.conf.

---
*PR created automatically by Jules for task [7032170248753563353](https://jules.google.com/task/7032170248753563353) started by @arran4*