### PR TITLE
Update PYTHON_COMPAT to support Python 3.15

### DIFF
--- a/dev-embedded/esp-idf/esp-idf-6.0.2.ebuild
+++ b/dev-embedded/esp-idf/esp-idf-6.0.2.ebuild
@@ -1,6 +1,6 @@
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..15} )
 inherit python-single-r1
 
 DESCRIPTION="Espressif IoT Development Framework"

--- a/dev-python/esp-coredump/esp-coredump-1.16.0.ebuild
+++ b/dev-python/esp-coredump/esp-coredump-1.16.0.ebuild
@@ -1,7 +1,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..15} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/esp-idf-diag/esp-idf-diag-0.2.0.ebuild
+++ b/dev-python/esp-idf-diag/esp-idf-diag-0.2.0.ebuild
@@ -1,7 +1,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..15} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/esp-idf-kconfig/esp-idf-kconfig-3.12.0.ebuild
+++ b/dev-python/esp-idf-kconfig/esp-idf-kconfig-3.12.0.ebuild
@@ -1,7 +1,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..15} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/esp-idf-monitor/esp-idf-monitor-1.9.0.ebuild
+++ b/dev-python/esp-idf-monitor/esp-idf-monitor-1.9.0.ebuild
@@ -1,7 +1,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..15} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/esp-idf-nvs-partition-gen/esp-idf-nvs-partition-gen-0.3.0.ebuild
+++ b/dev-python/esp-idf-nvs-partition-gen/esp-idf-nvs-partition-gen-0.3.0.ebuild
@@ -1,7 +1,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..15} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/esp-idf-panic-decoder/esp-idf-panic-decoder-1.5.0.ebuild
+++ b/dev-python/esp-idf-panic-decoder/esp-idf-panic-decoder-1.5.0.ebuild
@@ -1,7 +1,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..15} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/esp-idf-size/esp-idf-size-2.2.1.ebuild
+++ b/dev-python/esp-idf-size/esp-idf-size-2.2.1.ebuild
@@ -1,7 +1,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..15} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/esp-pylib/esp-pylib-1.1.2.ebuild
+++ b/dev-python/esp-pylib/esp-pylib-1.1.2.ebuild
@@ -1,7 +1,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..15} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/freertos-gdb/freertos-gdb-1.0.4.ebuild
+++ b/dev-python/freertos-gdb/freertos-gdb-1.0.4.ebuild
@@ -1,7 +1,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..15} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/idf-component-manager/idf-component-manager-3.1.0.ebuild
+++ b/dev-python/idf-component-manager/idf-component-manager-3.1.0.ebuild
@@ -1,7 +1,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..15} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/pyclang/pyclang-0.7.0.ebuild
+++ b/dev-python/pyclang/pyclang-0.7.0.ebuild
@@ -1,7 +1,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..15} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/pygdbmi/pygdbmi-0.11.0.0.ebuild
+++ b/dev-python/pygdbmi/pygdbmi-0.11.0.0.ebuild
@@ -1,7 +1,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..15} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/tree-sitter-c/tree-sitter-c-0.24.2.ebuild
+++ b/dev-python/tree-sitter-c/tree-sitter-c-0.24.2.ebuild
@@ -1,7 +1,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..15} )
 
 inherit distutils-r1 pypi
 


### PR DESCRIPTION
Expanded the `PYTHON_COMPAT` variable across `dev-embedded/esp-idf` and its dependencies in `dev-python/` to support Python versions 3.10 through 3.15. This fixes the issue where Portage could not resolve dependencies on systems with Python 3.13, 3.14, or 3.15 due to missing USE flag constraints for those versions.

Relevant test scripts (`verify_manifest.py`) were run to ensure validity.

---
*PR created automatically by Jules for task [13262938495093237621](https://jules.google.com/task/13262938495093237621) started by @arran4*