### PR TITLE
Fix workflow_builder release download URL in refresh-workflows

### DIFF
--- a/.github/workflows/app-admin-arrans-overlay-workflow-builder-bin-update.yaml
+++ b/.github/workflows/app-admin-arrans-overlay-workflow-builder-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-admin
   epn: arrans-overlay-workflow-builder-bin
   description: "A gentoo overlay ebuild workflow builder generator for -bin with a special purpose handler for .appimage binary files"

--- a/.github/workflows/app-admin-chezmoi-bin-update.yaml
+++ b/.github/workflows/app-admin-chezmoi-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-admin
   epn: chezmoi-bin
   description: "Manage your dotfiles across multiple diverse machines, securely."

--- a/.github/workflows/app-admin-ejson-bin-update.yaml
+++ b/.github/workflows/app-admin-ejson-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-admin
   epn: ejson-bin
   description: "EJSON is a small library to manage encrypted secrets using asymmetric encryption."

--- a/.github/workflows/app-admin-g2-bin-update.yaml
+++ b/.github/workflows/app-admin-g2-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-admin
   epn: g2-bin
   description: "g2 Gentoo Tools"

--- a/.github/workflows/app-emulation-86box-roms-update.yaml
+++ b/.github/workflows/app-emulation-86box-roms-update.yaml
@@ -15,6 +15,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ebuild_category: app-emulation
   ebuild_name: 86box-roms
   github_owner: 86Box

--- a/.github/workflows/app-misc-anytype-to-linkwarden-bin-update.yaml
+++ b/.github/workflows/app-misc-anytype-to-linkwarden-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-misc
   epn: anytype-to-linkwarden-bin
   description: "Simple application for migrating AnyType bookmarks to Linkwarden"

--- a/.github/workflows/app-misc-appimagetool-appimage-update.yaml
+++ b/.github/workflows/app-misc-appimagetool-appimage-update.yaml
@@ -15,6 +15,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-misc
   epn: appimagetool-appimage
   description: "AppImage tool to create AppImages (As an AppImage)"

--- a/.github/workflows/app-misc-chatbox-appimage-update.yaml
+++ b/.github/workflows/app-misc-chatbox-appimage-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-misc
   epn: chatbox-appimage
   description: "User-friendly Desktop Client App for AI Models/LLMs (GPT, Claude, Gemini, Ollama...)"

--- a/.github/workflows/app-misc-dua-cli-bin-update.yaml
+++ b/.github/workflows/app-misc-dua-cli-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-misc
   epn: dua-cli-bin
   description: "View disk space usage and delete unwanted data, fast."

--- a/.github/workflows/app-misc-flutter-google-datastore-appimage-update.yaml
+++ b/.github/workflows/app-misc-flutter-google-datastore-appimage-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-misc
   epn: flutter-google-datastore-appimage
   description: "Google Datastore and Datastore emulator client for \"easy\" modification of values"

--- a/.github/workflows/app-misc-flutter-jules-bin-update.yaml
+++ b/.github/workflows/app-misc-flutter-jules-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-misc
   epn: flutter-jules-bin
   description: "A comprehensive Flutter-based client application for interacting with the Google Jules API."

--- a/.github/workflows/app-misc-fq-bin-update.yaml
+++ b/.github/workflows/app-misc-fq-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-misc
   epn: fq-bin
   description: "jq for binary formats - tool, language and decoders for working with binary and text formats"

--- a/.github/workflows/app-misc-go-appimage-appimage-update.yaml
+++ b/.github/workflows/app-misc-go-appimage-appimage-update.yaml
@@ -15,6 +15,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-misc
   epn: go-appimage-appimage
   description: " Go implementation of AppImage tools "

--- a/.github/workflows/app-misc-gocdm-bin-update.yaml
+++ b/.github/workflows/app-misc-gocdm-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-misc
   epn: gocdm-bin
   description: "The Console Display Manager (Go Port)"

--- a/.github/workflows/app-misc-kjules-update.yaml
+++ b/.github/workflows/app-misc-kjules-update.yaml
@@ -15,6 +15,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ebuild_category: app-misc
   ebuild_name: kjules
   github_owner: arran4

--- a/.github/workflows/app-misc-kllamabooks-update.yaml
+++ b/.github/workflows/app-misc-kllamabooks-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}-kllamabooks
   cancel-in-progress: false
 
+env:
   ebuild_category: app-misc
   ebuild_name: kllamabooks
   github_owner: arran4

--- a/.github/workflows/app-misc-lemmy-notify-appimage-update.yaml
+++ b/.github/workflows/app-misc-lemmy-notify-appimage-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-misc
   epn: lemmy-notify-appimage
   description: "Lemmy Notification app - for desktop atm"

--- a/.github/workflows/app-misc-maid-appimage-update.yaml
+++ b/.github/workflows/app-misc-maid-appimage-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-misc
   epn: maid-appimage
   description: "Maid is a cross-platform Flutter app for interfacing with GGUF / llama.cpp models locally, and with Ollama and OpenAI models remotely."

--- a/.github/workflows/app-misc-mvcommon-bin-update.yaml
+++ b/.github/workflows/app-misc-mvcommon-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-misc
   epn: mvcommon-bin
   description: "Tool for moving files into a folder where they have a common prefix"

--- a/.github/workflows/app-misc-ollama-bin-update.yaml
+++ b/.github/workflows/app-misc-ollama-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-misc
   epn: ollama-bin
   description: "Get up and running with Llama 3, Mistral, Gemma, and other large language models."

--- a/.github/workflows/app-misc-picocrypt-bin-update.yaml
+++ b/.github/workflows/app-misc-picocrypt-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-misc
   epn: picocrypt-bin
   description: "A very small, very simple, yet very secure encryption tool."

--- a/.github/workflows/app-misc-rntocase-bin-update.yaml
+++ b/.github/workflows/app-misc-rntocase-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-misc
   epn: rntocase-bin
   description: "Some utilities to rename files, to upper, lower, title, camel, kebab, darwin case and many more"

--- a/.github/workflows/app-misc-shineyshot-bin-update.yaml
+++ b/.github/workflows/app-misc-shineyshot-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-misc
   epn: shineyshot-bin
   description: "A simple screenshotting tool with several user modes"

--- a/.github/workflows/app-misc-stability-matrix-appimage-update.yaml
+++ b/.github/workflows/app-misc-stability-matrix-appimage-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-misc
   epn: stability-matrix-appimage
   description: "Multi-Platform Package Manager for Stable Diffusion"

--- a/.github/workflows/app-misc-superfile-bin-update.yaml
+++ b/.github/workflows/app-misc-superfile-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-misc
   epn: superfile-bin
   description: "Pretty fancy and modern terminal file manager"

--- a/.github/workflows/app-misc-tuios-bin-update.yaml
+++ b/.github/workflows/app-misc-tuios-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-misc
   epn: tuios-bin
   description: "Terminal UI OS (Terminal Multiplexer)"

--- a/.github/workflows/app-text-jbofihe-update.yaml
+++ b/.github/workflows/app-text-jbofihe-update.yaml
@@ -15,6 +15,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ebuild_category: app-text
   ebuild_name: jbofihe
   github_owner: lojban

--- a/.github/workflows/app-text-md2png-bin-update.yaml
+++ b/.github/workflows/app-text-md2png-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-text
   epn: md2png-bin
   description: "Render Markdown directly to PNG or JPEG images with a single static Go binary."

--- a/.github/workflows/app-text-mdsplit-bin-update.yaml
+++ b/.github/workflows/app-text-mdsplit-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-text
   epn: mdsplit-bin
   description: "Splits markdown files into chunks suitable for processing with other tools or making into slides"

--- a/.github/workflows/app-text-mostcomm-bin-update.yaml
+++ b/.github/workflows/app-text-mostcomm-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: app-text
   epn: mostcomm-bin
   description: "A cli utility for finding the most common and sorting by length, lines-sets in a text file"

--- a/.github/workflows/dev-go-goreleaser-bin-update.yaml
+++ b/.github/workflows/dev-go-goreleaser-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: dev-go
   epn: goreleaser-bin
   description: "Deliver Go binaries as fast and easily as possible"

--- a/.github/workflows/dev-go-txtar-bin-update.yaml
+++ b/.github/workflows/dev-go-txtar-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: dev-go
   epn: txtar-bin
   description: "txtar enhanced and with a cli tool"

--- a/.github/workflows/dev-lang-dart-bin-update.yaml
+++ b/.github/workflows/dev-lang-dart-bin-update.yaml
@@ -7,6 +7,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ebuild_category: "dev-lang"
   ebuild_name: "dart-bin"
   description: " The Dart SDK, including the VM, dart2js, core libraries, and more."

--- a/.github/workflows/dev-lang-flutter-bin-update.yaml
+++ b/.github/workflows/dev-lang-flutter-bin-update.yaml
@@ -7,6 +7,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ebuild_category: "dev-lang"
   ebuild_name: "flutter-bin"
   description: "Flutter makes it easy and fast to build beautiful apps for mobile and beyond "

--- a/.github/workflows/dev-util-antigravity-bin-update.yaml
+++ b/.github/workflows/dev-util-antigravity-bin-update.yaml
@@ -12,6 +12,7 @@ on:
     paths:
       - '.github/workflows/dev-util-antigravity-bin-update.yaml'
 
+env:
   ecn: dev-util
   epn: antigravity-bin
   description: "Google Antigravity AI-driven IDE (binary release)"

--- a/.github/workflows/dev-util-antigravity-cli-bin-update.yaml
+++ b/.github/workflows/dev-util-antigravity-cli-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: dev-util
   epn: antigravity-cli-bin
   description: "Antigravity CLI"

--- a/.github/workflows/dev-util-codex-bin-update.yaml
+++ b/.github/workflows/dev-util-codex-bin-update.yaml
@@ -18,6 +18,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: dev-util
   epn: codex-bin
   description: "Lightweight coding agent that runs in your terminal"

--- a/.github/workflows/dev-util-codex-update.yaml
+++ b/.github/workflows/dev-util-codex-update.yaml
@@ -18,6 +18,7 @@ concurrency:
   group: ci-${{ github.ref }}-codex
   cancel-in-progress: false
 
+env:
   ecn: dev-util
   epn: codex
   description: "Lightweight coding agent that runs in your terminal"

--- a/.github/workflows/dev-util-editorconfig-guesser-bin-update.yaml
+++ b/.github/workflows/dev-util-editorconfig-guesser-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: dev-util
   epn: editorconfig-guesser-bin
   description: "Generates reasonable .editorconfig files for source files."

--- a/.github/workflows/dev-util-layerx-bin-update.yaml
+++ b/.github/workflows/dev-util-layerx-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: dev-util
   epn: layerx-bin
   description: "Interactive Docker image layer inspector"

--- a/.github/workflows/dev-vcs-git-credential-oauth-bin-update.yaml
+++ b/.github/workflows/dev-vcs-git-credential-oauth-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: dev-vcs
   epn: git-credential-oauth-bin
   description: "A Git credential helper that securely authenticates to GitHub, GitLab and BitBucket using OAuth."

--- a/.github/workflows/dev-vcs-git-tag-inc-bin-update.yaml
+++ b/.github/workflows/dev-vcs-git-tag-inc-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: dev-vcs
   epn: git-tag-inc-bin
   description: "Yet another semantic version incrementor and tagger for git"

--- a/.github/workflows/dev-vcs-kgithub-notify-update.yaml
+++ b/.github/workflows/dev-vcs-kgithub-notify-update.yaml
@@ -15,6 +15,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: dev-vcs
   epn: kgithub-notify
   description: "A sleek GitHub notification system tray application written natively in C++ using Qt6 and KDE Frameworks 6"

--- a/.github/workflows/media-sound-go-playerctl-bin-update.yaml
+++ b/.github/workflows/media-sound-go-playerctl-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: media-sound
   epn: go-playerctl-bin
   description: "mpris media player command-line controller for vlc, mpv, RhythmBox, web browsers, cmus, mpd, spotify and others"

--- a/.github/workflows/net-im-beeper-appimage-update.yaml
+++ b/.github/workflows/net-im-beeper-appimage-update.yaml
@@ -12,6 +12,7 @@ on:
     paths:
       - '.github/workflows/net-im-beeper-appimage-update.yaml'
 
+env:
   ecn: net-im
   epn: beeper-appimage
   description: "Unified chat client bridging multiple networks"

--- a/.github/workflows/net-im-caprine-appimage-update.yaml
+++ b/.github/workflows/net-im-caprine-appimage-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: net-im
   epn: caprine-appimage
   description: "Elegant Facebook Messenger desktop app"

--- a/.github/workflows/net-im-lemmy-notify-appimage-update.yaml
+++ b/.github/workflows/net-im-lemmy-notify-appimage-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: net-im
   epn: lemmy-notify-appimage
   description: "Lemmy Notification app - for desktop atm"

--- a/.github/workflows/net-im-slackdump-bin-update.yaml
+++ b/.github/workflows/net-im-slackdump-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: net-im
   epn: slackdump-bin
   description: "Save or export your private and public Slack messages, threads, files, and users locally without admin privileges."

--- a/.github/workflows/net-misc-abc-justin-rss-bin-update.yaml
+++ b/.github/workflows/net-misc-abc-justin-rss-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: net-misc
   epn: abc-justin-rss-bin
   description: "ABC news just-in to rss converter - generated"

--- a/.github/workflows/net-misc-kmagmux-update.yaml
+++ b/.github/workflows/net-misc-kmagmux-update.yaml
@@ -15,6 +15,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ebuild_category: net-misc
   ebuild_name: kmagmux
   github_owner: arran4

--- a/.github/workflows/net-misc-localsend-appimage-update.yaml
+++ b/.github/workflows/net-misc-localsend-appimage-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: net-misc
   epn: localsend-appimage
   description: "An open-source cross-platform alternative to AirDrop"

--- a/.github/workflows/net-misc-pimtrace-bin-update.yaml
+++ b/.github/workflows/net-misc-pimtrace-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: net-misc
   epn: pimtrace-bin
   description: "A CLI tool for preforming queries on ical and csv files"

--- a/.github/workflows/net-misc-podcast-cdr-manager-bin-update.yaml
+++ b/.github/workflows/net-misc-podcast-cdr-manager-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: net-misc
   epn: podcast-cdr-manager-bin
   description: "CLI tool to help manage podcast subscriptions for burning to CDROMs / CDR / CDRW"

--- a/.github/workflows/net-misc-reddit-tui-bin-update.yaml
+++ b/.github/workflows/net-misc-reddit-tui-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: net-misc
   epn: reddit-tui-bin
   description: "A lightweight terminal application for browsing Reddit from your command line."

--- a/.github/workflows/net-misc-rustdesk-appimage-update.yaml
+++ b/.github/workflows/net-misc-rustdesk-appimage-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: net-misc
   epn: rustdesk-appimage
   description: "An open-source remote desktop application designed for self-hosting, as an alternative to TeamViewer."

--- a/.github/workflows/net-misc-termscp-bin-update.yaml
+++ b/.github/workflows/net-misc-termscp-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: net-misc
   epn: termscp-bin
   description: "Feature rich terminal file transfer tool"

--- a/.github/workflows/refresh-workflows.yml
+++ b/.github/workflows/refresh-workflows.yml
@@ -21,12 +21,13 @@ jobs:
             echo "Failed to get latest version"
             exit 1
           fi
-          wget "https://github.com/arran4/arrans_overlay_workflow_builder/releases/download/${LATEST_VERSION}/arrans_overlay_workflow_builder_${LATEST_VERSION}_linux_amd64.tar.gz"
-          tar -xzf "arrans_overlay_workflow_builder_${LATEST_VERSION}_linux_amd64.tar.gz" overlay_workflow_builder_generator
+          VERSION_NUM=${LATEST_VERSION#v}
+          wget "https://github.com/arran4/arrans_overlay_workflow_builder/releases/download/${LATEST_VERSION}/arrans_overlay_workflow_builder_${VERSION_NUM}_linux_amd64.tar.gz"
+          tar -xzf "arrans_overlay_workflow_builder_${VERSION_NUM}_linux_amd64.tar.gz" overlay_workflow_builder_generator
           chmod +x overlay_workflow_builder_generator
           ./overlay_workflow_builder_generator
           rm overlay_workflow_builder_generator
-          rm "arrans_overlay_workflow_builder_${LATEST_VERSION}_linux_amd64.tar.gz"
+          rm "arrans_overlay_workflow_builder_${VERSION_NUM}_linux_amd64.tar.gz"
 
       - name: Discard non-substantive changes
         run: |

--- a/.github/workflows/sys-apps-lxa-bin-update.yaml
+++ b/.github/workflows/sys-apps-lxa-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: sys-apps
   epn: lxa-bin
   description: "A Linux-first file listing and inspection tool focused on extended attributes"

--- a/.github/workflows/www-apps-hugo-bin-update.yaml
+++ b/.github/workflows/www-apps-hugo-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: www-apps
   epn: hugo-bin
   description: "The world’s fastest framework for building websites."

--- a/.github/workflows/www-apps-pagefind-bin-update.yaml
+++ b/.github/workflows/www-apps-pagefind-bin-update.yaml
@@ -17,6 +17,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ecn: www-apps
   epn: pagefind-bin
   description: "Static low-bandwidth search at scale"

--- a/.github/workflows/www-misc-which_browser-update.yaml
+++ b/.github/workflows/www-misc-which_browser-update.yaml
@@ -15,6 +15,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+env:
   ebuild_category: www-misc
   ebuild_name: which_browser
   description: "Which Browser? A browser selecting tool with rules to automate."


### PR DESCRIPTION
Fixes the 404 Not Found error in the 'Refresh Workflows' automated GitHub action.
The release tag contains a 'v' prefix, but the asset artifact filename does not. Using bash parameter expansion `${LATEST_VERSION#v}` allows the action to correctly construct the filename of the tarball.

---
*PR created automatically by Jules for task [8156948397229048803](https://jules.google.com/task/8156948397229048803) started by @arran4*