### PR TITLE
Fix github-appimage type in current.config

### DIFF
--- a/current.config
+++ b/current.config
@@ -631,7 +631,7 @@ Binary arm64=>txtar_${TAG}_linux_arm64.tar.gz > txtar > txtar
 Document amd64=>txtar_${TAG}_linux_amd64.tar.gz > LICENSE > LICENSE
 Document amd64=>txtar_${TAG}_linux_amd64.tar.gz > README.md > README.md
 
-Type github-appimage
+Type Github AppImage Release
 GithubProjectUrl https://github.com/arran4/KMagMux
 Category net-misc
 EbuildName kmagmux


### PR DESCRIPTION
Extracted fix from pull request 778 to resolve generation error: Changed `Type github-appimage` to `Type Github AppImage Release` for kmagmux in current.config, as `github-appimage` causes the overlay workflow builder to fail with an unknown type error.

---
*PR created automatically by Jules for task [14847080021130170678](https://jules.google.com/task/14847080021130170678) started by @arran4*