### PR TITLE
Add net-im/buzz-appimage tracking workflow

### DIFF
--- a/.github/workflows/net-im-buzz-appimage-update.yaml
+++ b/.github/workflows/net-im-buzz-appimage-update.yaml
@@ -1,0 +1,172 @@
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.37 Github AppImage Release current.config 2026-08-12 10:40:34.04273759 +0000 UTC m=+0.008901529
+
+name: net-im/buzz-appimage update
+
+permissions:
+  contents: write
+
+on:
+  schedule:
+    - cron: '39 7 * * *'
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/net-im-buzz-appimage-update.yaml'
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  ecn: net-im
+  epn: buzz-appimage
+  description: "A hive mind communication platform"
+  homepage: "https://github.com/block/buzz"
+  github_owner: block
+  github_repo: buzz
+  keywords: ~amd64
+  workflow_filename: net-im-buzz-appimage-update.yaml
+  buzz_desktop_file: 'xyz.buzzapp.app.desktop'
+  buzz_appimage_installed_name: 'buzz.AppImage'
+  buzz_release_name_amd64: 'Buzz_${version}_amd64.AppImage'
+
+jobs:
+  check-and-create-ebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
+      - name: Process each release
+        id: process_releases
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p "$ebuild_dir"
+          metadata_file="${ebuild_dir}/metadata.xml"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:block/buzz" "$metadata_file"
+          declare -A releaseTypes=()
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          # shellcheck disable=SC2086
+          for tag in $tags; do
+            version="${tag#desktop-v}"
+            # shellcheck disable=SC2034
+            originalVersion="${version}"
+            if ! echo "${version}" | grep -E '^([0-9]+)\.([0-9]+)(\.([0-9]+))?(-r[0-9]+)?((_)(alpha|beta|rc|p)[0-9]*)*$'; then
+                echo "version: $version doesn't match regexp";
+                continue;
+            fi
+            releaseType="$(echo "${version}" | sed -n 's/^[^_]\+_\(alpha\|beta\|rc\|p[0-9]*\).*$/\1/p')"
+            if [[ ! -v releaseTypes[${releaseType:=release}] ]]; then
+                releaseTypes[${releaseType:=release}]="$version"
+            else
+                echo "Already have a newier ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
+                continue
+            fi
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
+              # shellcheck disable=SC2016
+              {
+                echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
+                echo 'EAPI=8'
+                echo "DESCRIPTION=\"${{ env.description }}\""
+                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'LICENSE="Apache-2.0"'
+                echo 'SLOT="0"'
+                echo 'KEYWORDS="${{ env.keywords }}"'
+                echo 'IUSE=""'
+                echo 'DEPEND=""'
+                echo 'RDEPEND="sys-fs/fuse:0"'
+                echo 'S="${WORKDIR}"'
+                echo 'RESTRICT="strip"'
+                echo ''
+                echo "inherit xdg-utils"
+                echo ''
+                echo 'SRC_URI="'
+                echo "  amd64? ( https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/Buzz_${version}_amd64.AppImage -> \${P}-Buzz_${version}_amd64.AppImage )"
+                echo '"'
+                echo ''
+                echo 'src_unpack() {'
+                echo '  if use amd64; then'
+                echo "    cp \"\${DISTDIR}/\${P}-${{ env.buzz_release_name_amd64 }}\" \"${{ env.buzz_appimage_installed_name }}\"  || die \"Can't copy downloaded file\""
+                echo '  fi'
+                echo '  chmod a+x "${{ env.buzz_appimage_installed_name }}"  || die "Can'\''t chmod archive file"'
+                echo '  "./${{ env.buzz_appimage_installed_name }}" --appimage-extract "${{ env.buzz_desktop_file }}" || die "Failed to extract .desktop from appimage"'
+                echo '  "./${{ env.buzz_appimage_installed_name }}" --appimage-extract "usr/share/icons" || die "Failed to extract hicolor icons from app image"'
+                echo '  "./${{ env.buzz_appimage_installed_name }}" --appimage-extract "*.png" || die "Failed to extract root icons from app image"'
+                echo '}'
+                echo ''
+                echo 'src_prepare() {'
+                echo "  sed -i 's:^Exec=.*:Exec=/opt/bin/${{ env.buzz_appimage_installed_name }}:' 'squashfs-root/${{ env.buzz_desktop_file }}'"
+                echo "  find squashfs-root -type f \( -name index.theme -or -name icon-theme.cache \) -exec rm {} \; "
+                echo "  find squashfs-root -type d -exec rmdir -p --ignore-fail-on-non-empty {} \; "
+                echo '  eapply_user'
+                echo '}'
+                echo ''
+                echo 'src_install() {'
+                echo '  exeinto /opt/bin'
+                echo '  doexe "${{ env.buzz_appimage_installed_name }}" || die "Failed to install AppImage"'
+                echo '  insinto /usr/share/applications'
+                echo '  doins "squashfs-root/${{ env.buzz_desktop_file }}" || die "Failed to install desktop file"'
+                echo '  insinto /usr/share/icons'
+                echo '  doins -r squashfs-root/usr/share/icons/hicolor || die "Failed to install icons"'
+                echo '  insinto /usr/share/pixmaps'
+                echo '  doins squashfs-root/*.png || die "Failed to install icons"'
+                echo '}'
+                echo ""
+                echo "pkg_postinst() {"
+                echo "  xdg_desktop_database_update"
+                echo "}"
+                echo ""
+
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/Buzz_${version}_amd64.AppImage" "${{ env.epn }}-${version}-Buzz_${version}_amd64.AppImage" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
+              echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
+          done
+          g2 ebuild deduplicate "${ebuild_dir}"
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint . ${{ env.ecn }}/${{ env.epn }}'
+
+      - name: Commit and push changes
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
+          git add "./${ebuild_dir}"
+          if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
+            git pull --rebase &&
+            git push
+          fi || true
+        if: steps.process_releases.outputs.generated_tag

--- a/.github/workflows/net-im-buzz-appimage-update.yaml
+++ b/.github/workflows/net-im-buzz-appimage-update.yaml
@@ -127,8 +127,8 @@ jobs:
                 echo ""
 
               } > "$tmp_ebuild_file"
-              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
-              if [ $? -eq 0 ]; then
+              if next_version=$(g2 ebuild next-revision --inspect "$tmp_ebuild_file" "${ebuild_dir}" "${version}"); then
+                  next_ebuild_file="${ebuild_dir}/${{ env.epn }}-${next_version}.ebuild"
                   echo "Content changed or new version for $version. Writing $next_ebuild_file"
                   mv "$tmp_ebuild_file" "$next_ebuild_file"
                   ebuild_file="$next_ebuild_file"

--- a/current.config
+++ b/current.config
@@ -38,6 +38,7 @@ DesktopFile lemmy_notify.desktop
 Icons hicolor-apps root
 Dependencies sys-libs/zlib sys-libs/glibc
 Binary amd64=>lemmy_notify-linux-x86_64.AppImage > lemmy_notify.AppImage
+
 Type Github AppImage Release
 GithubProjectUrl https://github.com/Mobile-Artificial-Intelligence/maid
 Category app-misc
@@ -641,3 +642,16 @@ Homepage https://github.com/arran4/KMagMux
 License GPL-3.0-or-later
 ProgramName KMagMux
 Dependencies kde-frameworks/kwallet:6 dev-qt/qtbase:6[dbus,gui,network,widgets,concurrent] kde-frameworks/kcoreaddons:6 kde-frameworks/ki18n:6 kde-frameworks/kxmlgui:6 kde-plasma/plasma-workspace:6 kde-frameworks/kio:6 kde-frameworks/knotifications:6
+
+Type Github AppImage Release
+GithubProjectUrl https://github.com/block/buzz
+Category net-im
+EbuildName buzz-appimage
+Description A hive mind communication platform
+Homepage https://github.com/block/buzz
+License Apache-2.0
+Workaround Semantic Version Without V
+ProgramName buzz
+DesktopFile xyz.buzzapp.app.desktop
+Icons hicolor-apps root
+Binary amd64=>Buzz_${PV}_amd64.AppImage > buzz.AppImage


### PR DESCRIPTION
Added the `net-im/buzz-appimage` tracking workflow for the `block/buzz` AppImage. The implementation includes the required config block in `current.config` and the generated auto-update workflow script `net-im-buzz-appimage-update.yaml`.

Since the `block/buzz` repository uses `desktop-v` as a prefix for releases but does not include this in its `.AppImage` asset names, the generated workflow was patched manually to parse the tag correctly (stripping `desktop-v`) and use the corrected variable substitutions in both the `SRC_URI` and `g2 manifest` commands.

---
*PR created automatically by Jules for task [16916656118589722205](https://jules.google.com/task/16916656118589722205) started by @arran4*