### PR TITLE
Fix dev-util/antigravity-cli-bin archived binary name

### DIFF
--- a/.github/workflows/dev-util-antigravity-cli-bin-update.yaml
+++ b/.github/workflows/dev-util-antigravity-cli-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.39 Github Binary Release current.config 2026-08-13 09:21:15.269769781 +0000 UTC m=+0.006636584
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 0.1.39 Github Binary Release current.config 2026-08-13 10:17:27.544184187 +0000 UTC m=+0.007535417
 
 name: dev-util/antigravity-cli-bin update
 
@@ -23,9 +23,9 @@ env:
   keywords: ~amd64 ~arm64
   workflow_filename: dev-util-antigravity-cli-bin-update.yaml
   agy_binary_installed_name: 'agy'
-  agy_binary_archived_name_amd64: 'antigravity'
+  agy_binary_archived_name_amd64: 'agy'
   agy_release_name_amd64: 'agy_cli_linux_x64.tar.gz'
-  agy_binary_archived_name_arm64: 'antigravity'
+  agy_binary_archived_name_arm64: 'agy'
   agy_release_name_arm64: 'agy_cli_linux_arm64.tar.gz'
 
 concurrency:

--- a/current.config
+++ b/current.config
@@ -611,6 +611,7 @@ Binary arm64=>layerx_linux_arm64.tar.gz > layerx > layerx
 Type Github Binary Release
 GithubProjectUrl https://github.com/google-antigravity/antigravity-cli
 Category dev-util
+# renamed antigravity to agy as a temporary/one version bug workaround
 EbuildName antigravity-cli-bin.ebuild
 Description Antigravity CLI
 Homepage https://github.com/google-antigravity/antigravity-cli
@@ -618,8 +619,8 @@ License Apache-2.0
 Workaround Semantic Version Without V
 Workaround Semantic Version Prerelease Hack 1
 ProgramName agy
-Binary amd64=>agy_cli_linux_x64.tar.gz > antigravity > agy
-Binary arm64=>agy_cli_linux_arm64.tar.gz > antigravity > agy
+Binary amd64=>agy_cli_linux_x64.tar.gz > agy > agy
+Binary arm64=>agy_cli_linux_arm64.tar.gz > agy > agy
 
 Type Github Binary Release
 GithubProjectUrl https://github.com/arran4/txtar


### PR DESCRIPTION
Renamed the archived binary target name for `dev-util/antigravity-cli-bin` from `antigravity` to `agy` inside `current.config` to act as a temporary or one-version bug workaround as requested. It successfully regenerated `dev-util-antigravity-cli-bin-update.yaml` to include this modification.

---
*PR created automatically by Jules for task [1460234253281181893](https://jules.google.com/task/1460234253281181893) started by @arran4*