### PR TITLE
Fix maintainer definition for net-im/beeper-appimage

### DIFF
--- a/net-im/beeper-appimage/metadata.xml
+++ b/net-im/beeper-appimage/metadata.xml
@@ -1,3 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-<pkgmetadata></pkgmetadata>
+<pkgmetadata>
+    <maintainer type="person">
+        <email>gentoo@arran4.com</email>
+        <name>Arran Ubels</name>
+    </maintainer>
+</pkgmetadata>


### PR DESCRIPTION
Added Arran Ubels as the maintainer for net-im/beeper-appimage to fix metadata QA errors.

---
*PR created automatically by Jules for task [13190303683145657623](https://jules.google.com/task/13190303683145657623) started by @arran4*