### PR TITLE
chore: fix news author to Arran

### DIFF
--- a/metadata/news/2024-07-22-flatpak-migration/2024-07-22-flatpak-migration.en.txt
+++ b/metadata/news/2024-07-22-flatpak-migration/2024-07-22-flatpak-migration.en.txt
@@ -1,6 +1,5 @@
 Title: Migration to Flatpak for several applications
 Author: Arran <gentoo@arran4.com>
-Author: Jules <gentoo@arran4.com>
 Posted: 2026-07-22
 Revision: 1
 News-Item-Format: 2.0

--- a/metadata/news/2024-08-10-fq-bin-deletion/2024-08-10-fq-bin-deletion.en.txt
+++ b/metadata/news/2024-08-10-fq-bin-deletion/2024-08-10-fq-bin-deletion.en.txt
@@ -1,6 +1,5 @@
 Title: Removal of app-misc/fq-bin in favor of dev-util/fq
 Author: Arran <gentoo@arran4.com>
-Author: Jules <gentoo@arran4.com>
 Posted: 2024-08-10
 Revision: 1
 News-Item-Format: 2.0

--- a/metadata/news/2024-08-10-lemmy-notify-appimage-category-migration/2024-08-10-lemmy-notify-appimage-category-migration.en.txt
+++ b/metadata/news/2024-08-10-lemmy-notify-appimage-category-migration/2024-08-10-lemmy-notify-appimage-category-migration.en.txt
@@ -1,6 +1,5 @@
 Title: Migration of lemmy-notify-appimage to net-im category
 Author: Arran <gentoo@arran4.com>
-Author: Jules <gentoo@arran4.com>
 Posted: 2024-08-10
 Revision: 1
 News-Item-Format: 2.0

--- a/metadata/news/2026-08-10-rustdesk-flatpak-migration/2026-08-10-rustdesk-flatpak-migration.en.txt
+++ b/metadata/news/2026-08-10-rustdesk-flatpak-migration/2026-08-10-rustdesk-flatpak-migration.en.txt
@@ -1,6 +1,5 @@
 Title: Migration to Flatpak for RustDesk, Caprine, LocalSend, and Picocrypt
 Author: Arran <gentoo@arran4.com>
-Author: Jules <gentoo@arran4.com>
 Posted: 2026-08-10
 Revision: 2
 News-Item-Format: 2.0

--- a/metadata/news/2026-08-13-antigravity-migration/2026-08-13-antigravity-migration.en.txt
+++ b/metadata/news/2026-08-13-antigravity-migration/2026-08-13-antigravity-migration.en.txt
@@ -1,5 +1,5 @@
 Title: Removal of dev-util/antigravity-bin and dev-util/antigravity-cli-bin in favor of GURU packages
-Author: Jules <gentoo@arran4.com>
+Author: Arran <gentoo@arran4.com>
 Posted: 2026-08-13
 Revision: 1
 News-Item-Format: 2.0


### PR DESCRIPTION
This PR fixes the author metadata in the Gentoo news text files under `metadata/news`. It ensures that all news items correctly list `Arran <gentoo@arran4.com>` as the author instead of the incorrect or duplicate author `Jules <gentoo@arran4.com>`.

All files under `metadata/news` ending in `.txt` were checked and updated accordingly.

---
*PR created automatically by Jules for task [6568629528120370986](https://jules.google.com/task/6568629528120370986) started by @arran4*