### PR TITLE
ci: simplify pkgcheck commit detection

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Run pkgcheck
         uses: pkgcore/pkgcheck-action@v1
         with:
-          args: --keywords=-UnknownManifest --commits ${{ github.event.pull_request.base.ref && format('origin/{0}', github.event.pull_request.base.ref) || 'HEAD~1' }}
+          args: --keywords=-UnknownManifest --commits
 
   g2-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Replaced the manual and complex commit range argument for `pkgcheck scan --commits` with the native flag without arguments. Modern `pkgcheck` versions correctly detect the commits to scan, which fixes an issue with `pkgcheck ci` checkout requirements and conforms to best practices.

---
*PR created automatically by Jules for task [6045401037528383247](https://jules.google.com/task/6045401037528383247) started by @arran4*