### PR TITLE
Fix historical dev-ml package migration metadata

### DIFF
--- a/metadata/news/2024-09-21-dev-ml-move/2024-09-21-dev-ml-move.en.txt
+++ b/metadata/news/2024-09-21-dev-ml-move/2024-09-21-dev-ml-move.en.txt
@@ -1,0 +1,44 @@
+Title: Migration of AI packages from dev-ml to app-misc
+Author: Arran <gentoo@arran4.com>
+Posted: 2024-09-21
+Revision: 1
+News-Item-Format: 2.0
+Display-If-Installed: dev-ml/llamafile-bin
+Display-If-Installed: app-misc/llamafile-bin
+Display-If-Installed: dev-ml/llm-compiler-13b-ftd-llamafile-bin
+Display-If-Installed: app-misc/llm-compiler-13b-ftd-llamafile-bin
+Display-If-Installed: dev-ml/moondream2llamafile-bin
+Display-If-Installed: app-misc/moondream2llamafile-bin
+Display-If-Installed: dev-ml/ollama-bin
+Display-If-Installed: app-misc/ollama-bin
+Display-If-Installed: dev-ml/whisperfile-bin
+Display-If-Installed: app-misc/whisperfile-bin
+
+On 2024-09-21, several AI and LLM application packages were moved from the
+`dev-ml` category to `app-misc`.  This followed issue #8, which pointed out
+that Gentoo's `dev-ml` category is intended for OCaml packages.
+
+The affected package moves are:
+
+  dev-ml/llamafile-bin -> app-misc/llamafile-bin
+  dev-ml/llm-compiler-13b-ftd-llamafile-bin -> app-misc/llm-compiler-13b-ftd-llamafile-bin
+  dev-ml/moondream2llamafile-bin -> app-misc/moondream2llamafile-bin
+  dev-ml/ollama-bin -> app-misc/ollama-bin
+  dev-ml/whisperfile-bin -> app-misc/whisperfile-bin
+
+The original migration did not include the corresponding `profiles/updates`
+move entries.  As a result, systems which installed one of these packages
+before the migration may still record the old `dev-ml` package atom in the
+installed package database.  This can cause file collisions when Portage
+tries to install the replacement from `app-misc`.
+
+The overlay now contains the missing package move metadata.  After syncing,
+Portage normally applies repository updates automatically.  If an old
+`dev-ml` atom remains installed, the installed package database can be
+updated explicitly with:
+
+  emaint --fix moveinst
+
+No manual deselection, unmerge, or reinstall of the old category is required
+solely for this category migration.  After the move metadata has been
+applied, update the package normally from its `app-misc` location.

--- a/profiles/updates/3Q-2024
+++ b/profiles/updates/3Q-2024
@@ -1,0 +1,5 @@
+move dev-ml/llamafile-bin app-misc/llamafile-bin
+move dev-ml/llm-compiler-13b-ftd-llamafile-bin app-misc/llm-compiler-13b-ftd-llamafile-bin
+move dev-ml/moondream2llamafile-bin app-misc/moondream2llamafile-bin
+move dev-ml/ollama-bin app-misc/ollama-bin
+move dev-ml/whisperfile-bin app-misc/whisperfile-bin


### PR DESCRIPTION
## Summary

Repair the September 2024 category migration from `dev-ml` to `app-misc` that followed issue #8.

The package directories were moved at the time, but the corresponding repository update metadata was never added. As a result, systems with an older package installed under `dev-ml` can retain that old category in the installed package database and hit file collisions when installing the current `app-misc` package, such as `/opt/bin/ollama` for `ollama-bin`.

## Changes

- add `profiles/updates/3Q-2024` with the five package moves performed on 2024-09-21:
  - `dev-ml/llamafile-bin` -> `app-misc/llamafile-bin`
  - `dev-ml/llm-compiler-13b-ftd-llamafile-bin` -> `app-misc/llm-compiler-13b-ftd-llamafile-bin`
  - `dev-ml/moondream2llamafile-bin` -> `app-misc/moondream2llamafile-bin`
  - `dev-ml/ollama-bin` -> `app-misc/ollama-bin`
  - `dev-ml/whisperfile-bin` -> `app-misc/whisperfile-bin`
- add a backdated 2024-09-21 GLEP 42 news item explaining the migration and the missing move metadata
- target the news item at both old and new installed atoms so it remains relevant before or after Portage applies the VDB move
- document `emaint --fix moveinst` as the explicit recovery command when an old `dev-ml` atom remains installed

## Why

Gentoo repository package/category moves must be recorded in `profiles/updates/` so package managers can update installed metadata and configuration consistently. The original migration changed the repository paths but omitted these move records.

This is a follow-up to #8 and fixes the migration metadata rather than changing the current package layout.

## Validation

- compared the migration commit from 2024-09-21 to confirm all five affected package paths
- verified the repository uses profile EAPI 8
- kept the updates file in the repository's documented quarterly naming convention (`3Q-2024`)
- used a GLEP 42-compatible news filename with a short name under the 20-character limit
