### PR TITLE
Add GitHub Action workflow for Gentoo package testing

### DIFF
--- a/.github/workflows/gentoo-pkg-test.yml
+++ b/.github/workflows/gentoo-pkg-test.yml
@@ -89,20 +89,29 @@ jobs:
           mkdir -p /etc/portage/package.accept_keywords
           echo "*/*::arrans-overlay ~amd64" > /etc/portage/package.accept_keywords/arrans-overlay
 
+          # Install pkgcheck
+          emerge -v dev-util/pkgcheck
+
           PACKAGES="$1"
 
           FAILED_PACKAGES=""
           for PKG in $PACKAGES; do
+            echo "Running pkgcheck on $PKG"
+            if ! pkgcheck scan /var/db/repos/arrans_overlay/${PKG#=}; then
+              echo "pkgcheck failed for $PKG"
+              FAILED_PACKAGES="$FAILED_PACKAGES $PKG (pkgcheck)"
+            fi
+
             echo "Building and testing $PKG"
             # Actually build and install the package to verify it works
             if ! emerge -v $PKG; then
               echo "Failed to emerge $PKG"
-              FAILED_PACKAGES="$FAILED_PACKAGES $PKG"
+              FAILED_PACKAGES="$FAILED_PACKAGES $PKG (emerge)"
             fi
           done
 
           if [ -n "$FAILED_PACKAGES" ]; then
-            echo "The following packages failed to build or install: $FAILED_PACKAGES"
+            echo "The following packages failed to build, install, or pass pkgcheck: $FAILED_PACKAGES"
             exit 1
           fi
           INNEREOF
@@ -112,8 +121,10 @@ jobs:
           docker cp test_packages.sh gentoo:/tmp/test_packages.sh
           docker exec gentoo /tmp/test_packages.sh "$PACKAGES"
 
-      - name: Clean up containers
+      - name: Stop and clean up containers
         if: always()
         run: |
+          docker stop gentoo || true
+          docker stop portage || true
           docker rm --force gentoo || true
           docker rm --force portage || true

--- a/.github/workflows/gentoo-pkg-test.yml
+++ b/.github/workflows/gentoo-pkg-test.yml
@@ -1,0 +1,119 @@
+name: Gentoo Package Test
+
+on:
+  schedule:
+    - cron: '0 0 1 * *' # Once a month
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '**/*.ebuild'
+      - '.github/workflows/gentoo-pkg-test.yml'
+
+concurrency:
+  group: gentoo-pkg-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-packages:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Start Gentoo stage3
+        run: |
+          docker pull gentoo/stage3:latest
+          docker pull gentoo/portage:latest
+          docker create --name portage gentoo/portage:latest
+          docker run --detach \
+            --name gentoo \
+            --volumes-from portage \
+            --volume "${GITHUB_WORKSPACE}:/var/db/repos/arrans_overlay:ro" \
+            gentoo/stage3:latest \
+            sleep infinity
+
+      - name: Determine changed packages
+        id: changed-packages
+        run: |
+          # If it's a pull request, get changed files (Added, Copied, Modified, Renamed)
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            CHANGED_FILES=$(git diff --diff-filter=ACMR --name-only origin/${{ github.base_ref }} HEAD)
+          else
+            # For manual or schedule, test all packages in overlay
+            CHANGED_FILES=$(find . -name "*.ebuild")
+          fi
+
+          PACKAGES=""
+          for FILE in $CHANGED_FILES; do
+            if [[ $FILE == *.ebuild ]]; then
+              # Strip leading ./ if present
+              FILE=${FILE#./}
+              CATEGORY=$(echo $FILE | cut -d/ -f1)
+              PACKAGE=$(echo $FILE | cut -d/ -f2)
+              # Extract package version from filename to test the specific ebuild
+              EBUILD_NAME=$(basename $FILE)
+              VERSION=${EBUILD_NAME%.ebuild}
+              PACKAGES="$PACKAGES =$CATEGORY/$VERSION"
+            fi
+          done
+
+          # Remove duplicates
+          PACKAGES=$(echo $PACKAGES | tr ' ' '\n' | sort -u | tr '\n' ' ')
+
+          echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
+          echo "Packages to test: $PACKAGES"
+
+      - name: Install and test packages
+        if: steps.changed-packages.outputs.packages != ''
+        run: |
+          PACKAGES="${{ steps.changed-packages.outputs.packages }}"
+
+          # Create a script to run inside the docker container
+          cat << 'INNEREOF' > test_packages.sh
+          #!/bin/bash
+          set -euxo pipefail
+
+          mkdir -p /etc/portage/repos.conf
+          printf "%s\n" \
+            "[arrans-overlay]" \
+            "location = /var/db/repos/arrans_overlay" \
+            "masters = gentoo" \
+            "auto-sync = no" \
+            > /etc/portage/repos.conf/arrans-overlay.conf
+
+          # Unmask all packages in the overlay for testing
+          mkdir -p /etc/portage/package.accept_keywords
+          echo "*/*::arrans-overlay ~amd64" > /etc/portage/package.accept_keywords/arrans-overlay
+
+          PACKAGES="$1"
+
+          FAILED_PACKAGES=""
+          for PKG in $PACKAGES; do
+            echo "Building and testing $PKG"
+            # Actually build and install the package to verify it works
+            if ! emerge -v $PKG; then
+              echo "Failed to emerge $PKG"
+              FAILED_PACKAGES="$FAILED_PACKAGES $PKG"
+            fi
+          done
+
+          if [ -n "$FAILED_PACKAGES" ]; then
+            echo "The following packages failed to build or install: $FAILED_PACKAGES"
+            exit 1
+          fi
+          INNEREOF
+          sed -i 's/exit/exit/g' test_packages.sh
+
+          chmod +x test_packages.sh
+          docker cp test_packages.sh gentoo:/tmp/test_packages.sh
+          docker exec gentoo /tmp/test_packages.sh "$PACKAGES"
+
+      - name: Clean up containers
+        if: always()
+        run: |
+          docker rm --force gentoo || true
+          docker rm --force portage || true


### PR DESCRIPTION
This PR adds a GitHub Action workflow to automatically test Gentoo packages within a `gentoo/stage3` Docker container. It is designed to catch dependency resolution errors and build issues automatically, such as those seen in PR #780.

The workflow:
- Uses official Gentoo Docker containers (`gentoo/stage3` and `gentoo/portage`).
- Runs monthly or manually to test all ebuilds in the overlay.
- Runs on pull requests, intelligently testing only the added or modified ebuilds.
- Verifies packages by attempting to emerge (build and install) them, failing the run if any package cannot be resolved or built.

---
*PR created automatically by Jules for task [9648091656444672822](https://jules.google.com/task/9648091656444672822) started by @arran4*