### PR TITLE
docs: Add tee method for manual repository installation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,17 @@ sync-type = git
 sync-uri = https://github.com/gentoo-mirror/arrans-overlay.git
 ```
 
+Alternatively, you can create the file using `tee`:
+
+```console
+$ sudo tee /etc/portage/repos.conf/arrans-overlay.conf << EOF
+[arrans-overlay]
+location = /var/db/repos/arrans-overlay
+sync-type = git
+sync-uri = https://github.com/gentoo-mirror/arrans-overlay.git
+EOF
+```
+
 Afterwards, simply run `emerge --sync`, and Portage should seamlessly make all our ebuilds available.
 
 ## Links


### PR DESCRIPTION
Adds an alternative manual installation instruction using `sudo tee` and a heredoc to create the `/etc/portage/repos.conf/arrans-overlay.conf` file.

---
*PR created automatically by Jules for task [14798958543471062114](https://jules.google.com/task/14798958543471062114) started by @arran4*