### PR TITLE
app-misc/kjules: Fix QA notice by inheriting xdg ecm

### DIFF
--- a/.github/workflows/app-misc-kjules-update.yaml
+++ b/.github/workflows/app-misc-kjules-update.yaml
@@ -68,7 +68,7 @@ jobs:
                 echo "# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/app-misc-kjules-update.yaml"
                 echo "EAPI=8"
                 echo ""
-                echo "inherit ecm"
+                echo "inherit xdg ecm"
                 echo ""
                 echo "DESCRIPTION=\"$description\""
                 echo "HOMEPAGE=\"$homepage\""

--- a/app-misc/kjules/kjules-0.0.76.ebuild
+++ b/app-misc/kjules/kjules-0.0.76.ebuild
@@ -1,7 +1,7 @@
 # Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/app-misc-kjules-update.yaml
 EAPI=8
 
-inherit ecm
+inherit xdg ecm
 
 DESCRIPTION="kjules KDE application"
 HOMEPAGE="https://github.com/arran4/kjules"


### PR DESCRIPTION
Fixes the QA notice about un-updated icon caches during install of app-misc/kjules. This adds `xdg` to the inherit list right before `ecm`, which correctly registers the `pkg_postinst` hooks from xdg without overriding the CMake prepare steps in `ecm`.

---
*PR created automatically by Jules for task [16697306719408286712](https://jules.google.com/task/16697306719408286712) started by @arran4*