### PR TITLE
Fix invalid news item headers

### DIFF
--- a/metadata/news/2026-08-20-codex-removed/2026-08-20-codex-removed.en.txt
+++ b/metadata/news/2026-08-20-codex-removed/2026-08-20-codex-removed.en.txt
@@ -3,7 +3,8 @@ Author: Arran Ubels <gentoo@arran4.com>
 Posted: 2026-08-20
 Revision: 1
 News-Item-Format: 2.0
-Display-If-Installed: dev-util/codex dev-util/codex-bin
+Display-If-Installed: dev-util/codex
+Display-If-Installed: dev-util/codex-bin
 
 The packages dev-util/codex and dev-util/codex-bin have been added to the official guru repository.
 They have been removed from this overlay to avoid collisions.


### PR DESCRIPTION
The `2026-08-20-codex-removed` news item had multiple package dependencies on a single `Display-If-Installed` line, which violates GLEP 42 format resulting in an "Invalid news item" error. This PR splits the dependencies onto separate lines.

---
*PR created automatically by Jules for task [4779259029252794414](https://jules.google.com/task/4779259029252794414) started by @arran4*