### PR TITLE
Add automated font-logos packaging workflow

### DIFF
--- a/.github/scripts/update-font-logos.sh
+++ b/.github/scripts/update-font-logos.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="${1:-.}"
+category="media-fonts"
+package="font-logos"
+upstream_owner="lukas-w"
+upstream_repo="font-logos"
+package_dir="${root_dir}/${category}/${package}"
+
+api_headers=(
+  -H 'Accept: application/vnd.github+json'
+  -H 'X-GitHub-Api-Version: 2022-11-28'
+)
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+  api_headers+=( -H "Authorization: Bearer ${GITHUB_TOKEN}" )
+fi
+
+release_json="$(curl -fsSL "${api_headers[@]}" \
+  "https://api.github.com/repos/${upstream_owner}/${upstream_repo}/releases/latest")"
+tag="$(jq -r '.tag_name // empty' <<<"${release_json}")"
+
+if [[ ! "${tag}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+  echo "Unsupported or missing upstream release tag: ${tag:-<empty>}" >&2
+  exit 1
+fi
+
+version="${BASH_REMATCH[1]}"
+asset_name="${package}-${version}.zip"
+asset_url="$(jq -r --arg name "${asset_name}" '.assets[] | select(.name == $name) | .browser_download_url' <<<"${release_json}" | head -n1)"
+
+if [[ -z "${asset_url}" || "${asset_url}" == "null" ]]; then
+  echo "Release ${tag} does not contain ${asset_name}" >&2
+  exit 1
+fi
+
+mkdir -p "${package_dir}"
+
+metadata_file="${package_dir}/metadata.xml"
+if [[ ! -f "${metadata_file}" ]]; then
+  cat >"${metadata_file}" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+    <maintainer type="person">
+        <email>gentoo@arran4.com</email>
+        <name>Arran Ubels</name>
+    </maintainer>
+    <upstream>
+        <remote-id type="github">lukas-w/font-logos</remote-id>
+    </upstream>
+</pkgmetadata>
+EOF
+fi
+
+ebuild_file="${package_dir}/${package}-${version}.ebuild"
+changed=false
+if [[ ! -f "${ebuild_file}" ]]; then
+  cat >"${ebuild_file}" <<'EOF'
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit font
+
+DESCRIPTION="Icon font containing logos of Linux distributions and open source software"
+HOMEPAGE="https://github.com/lukas-w/font-logos"
+SRC_URI="https://github.com/lukas-w/font-logos/releases/download/v${PV}/${P}.zip"
+
+LICENSE="Unlicense"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86"
+
+BDEPEND="app-arch/unzip"
+
+FONT_SUFFIX="ttf"
+FONT_S="${S}/assets"
+
+DOCS=( README.md )
+EOF
+
+  g2 manifest upsert-from-url "${asset_url}" "${asset_name}" "${package_dir}/Manifest"
+  changed=true
+elif [[ ! -s "${package_dir}/Manifest" ]]; then
+  g2 manifest upsert-from-url "${asset_url}" "${asset_name}" "${package_dir}/Manifest"
+  changed=true
+fi
+
+echo "font-logos latest release: ${version}"
+echo "ebuild: ${ebuild_file}"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "version=${version}"
+    echo "tag=${tag}"
+    echo "asset_url=${asset_url}"
+    echo "ebuild=${ebuild_file}"
+    echo "changed=${changed}"
+  } >>"${GITHUB_OUTPUT}"
+fi

--- a/.github/workflows/media-fonts-font-logos-update.yml
+++ b/.github/workflows/media-fonts-font-logos-update.yml
@@ -1,0 +1,62 @@
+name: media-fonts/font-logos Update
+
+on:
+  schedule:
+    - cron: '17 3 * * 1'
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/media-fonts-font-logos-update.yml'
+      - '.github/scripts/update-font-logos.sh'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: media-fonts-font-logos-update
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
+      - name: Generate latest ebuild
+        id: generate
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/update-font-logos.sh
+
+      - name: Check generated changes
+        if: steps.generate.outputs.changed == 'true'
+        run: |
+          git diff --check
+          test -s "media-fonts/font-logos/font-logos-${{ steps.generate.outputs.version }}.ebuild"
+          test -s media-fonts/font-logos/Manifest
+          test -s media-fonts/font-logos/metadata.xml
+
+      - name: Create update pull request
+        if: steps.generate.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "media-fonts/font-logos: add ${{ steps.generate.outputs.version }}"
+          branch: update-media-fonts-font-logos
+          delete-branch: true
+          title: "media-fonts/font-logos: add ${{ steps.generate.outputs.version }}"
+          body: |
+            Automated update for `media-fonts/font-logos` from the latest upstream GitHub release.
+
+            Upstream release: `${{ steps.generate.outputs.tag }}`
+            Release asset: `${{ steps.generate.outputs.asset_url }}`
+
+            The package installs the prebuilt TTF through Gentoo's `font` eclass; it does not build the font-generation toolchain or install the npm package.
+          labels: automated pr

--- a/.github/workflows/media-fonts-font-logos-verify.yml
+++ b/.github/workflows/media-fonts-font-logos-verify.yml
@@ -1,0 +1,93 @@
+name: media-fonts/font-logos Verification
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/scripts/update-font-logos.sh'
+      - '.github/workflows/media-fonts-font-logos-update.yml'
+      - '.github/workflows/media-fonts-font-logos-verify.yml'
+      - 'media-fonts/font-logos/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/scripts/update-font-logos.sh'
+      - '.github/workflows/media-fonts-font-logos-update.yml'
+      - '.github/workflows/media-fonts-font-logos-verify.yml'
+      - 'media-fonts/font-logos/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: media-fonts-font-logos-verify-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check generator syntax
+        run: bash -n .github/scripts/update-font-logos.sh
+
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
+      - name: Generate package in a temporary tree
+        id: generate
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          generated_root="${RUNNER_TEMP}/font-logos-generated"
+          mkdir -p "${generated_root}"
+          bash .github/scripts/update-font-logos.sh "${generated_root}"
+
+      - name: Verify generated Gentoo files
+        run: |
+          package_dir="${RUNNER_TEMP}/font-logos-generated/media-fonts/font-logos"
+          ebuild="${package_dir}/font-logos-${{ steps.generate.outputs.version }}.ebuild"
+
+          test -s "${ebuild}"
+          test -s "${package_dir}/Manifest"
+          test -s "${package_dir}/metadata.xml"
+          grep -Fxq 'inherit font' "${ebuild}"
+          grep -Fxq 'FONT_SUFFIX="ttf"' "${ebuild}"
+          grep -Fxq 'FONT_S="${S}/assets"' "${ebuild}"
+          grep -q "DIST font-logos-${{ steps.generate.outputs.version }}.zip " "${package_dir}/Manifest"
+
+          python3 - "${package_dir}/metadata.xml" <<'PY'
+          import sys
+          import xml.etree.ElementTree as ET
+          ET.parse(sys.argv[1])
+          PY
+
+      - name: Verify upstream release asset contents
+        env:
+          ASSET_URL: ${{ steps.generate.outputs.asset_url }}
+          VERSION: ${{ steps.generate.outputs.version }}
+        run: |
+          archive="${RUNNER_TEMP}/font-logos.zip"
+          curl -fsSL --retry 3 -o "${archive}" "${ASSET_URL}"
+          python3 - "${archive}" "${VERSION}" <<'PY'
+          import sys
+          import zipfile
+
+          archive, version = sys.argv[1:]
+          prefix = f"font-logos-{version}/assets/"
+          required = {
+              prefix + "font-logos.ttf",
+              prefix + "font-logos.woff",
+              prefix + "font-logos.woff2",
+              prefix + "font-logos.css",
+          }
+          with zipfile.ZipFile(archive) as zf:
+              names = set(zf.namelist())
+          missing = sorted(required - names)
+          if missing:
+              raise SystemExit("missing expected release files: " + ", ".join(missing))
+          PY


### PR DESCRIPTION
Adds Gentoo-native automation for `lukas-w/font-logos` without using npm or rebuilding the upstream font-generation toolchain.

### What this adds
- `.github/scripts/update-font-logos.sh`
  - discovers the latest `vX.Y.Z` GitHub release
  - requires the matching `font-logos-X.Y.Z.zip` release asset
  - generates `media-fonts/font-logos/font-logos-X.Y.Z.ebuild`
  - creates package metadata when needed
  - generates the Manifest with `g2 manifest upsert-from-url`
- `media-fonts/font-logos Update`
  - weekly schedule plus manual dispatch
  - also runs when the updater workflow/generator itself changes on `main`
  - opens an automated package-update PR rather than pushing package changes directly to `main`
- `media-fonts/font-logos Verification`
  - path-scoped to this package and its automation
  - 5-minute timeout
  - generates into a temporary tree
  - verifies ebuild, Manifest, metadata XML, and expected upstream ZIP contents
  - avoids a full overlay/Gentoo build to keep feedback fast

The generated ebuild uses `inherit font`, installs the prebuilt TTF from the upstream release ZIP, and only requires `app-arch/unzip` at build time.

After this PR is merged, the updater's `push.paths` trigger will run it immediately and create the initial `media-fonts/font-logos` package PR for the current upstream release.