### PR TITLE
app-misc/vwm: add live ebuild

### DIFF
--- a/app-misc/vwm/files/vwm-9999-system-libraries.patch
+++ b/app-misc/vwm/files/vwm-9999-system-libraries.patch
@@ -1,0 +1,42 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -28,23 +28,11 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+ #find_package(PROTOTHREAD REQUIRED)
+ 
+ find_package(VTERM REQUIRED)
++include_directories(BEFORE ${VTERM_INCLUDE_DIRS})
+ 
+-# use libviper source tree (headers + library not yet installed).
+-# Defaults to a sibling checkout (../libviper); override with
+-# -DLIBVIPER_SOURCE_DIR=/path/to/libviper at configure time.
+-set(LIBVIPER_SOURCE_DIR "${PROJECT_SOURCE_DIR}/../libviper"
+-    CACHE PATH "Path to the libviper source tree (contains vdk/, vkmio/, libvdk.so)")
+-get_filename_component(LIBVIPER_SOURCE_DIR "${LIBVIPER_SOURCE_DIR}" ABSOLUTE)
+-
+-if(NOT EXISTS "${LIBVIPER_SOURCE_DIR}/libvdk.so")
+-  message(FATAL_ERROR
+-    "libvdk.so not found at ${LIBVIPER_SOURCE_DIR}/libvdk.so. "
+-    "Build libviper first, or pass -DLIBVIPER_SOURCE_DIR=<path> "
+-    "to point at your libviper checkout.")
+-endif()
+-
+-include_directories(BEFORE ${LIBVIPER_SOURCE_DIR}/vdk ${LIBVIPER_SOURCE_DIR}/vkmio)
+-set(VDK_LIBRARY "${LIBVIPER_SOURCE_DIR}/libvdk.so")
++find_package(VDK REQUIRED)
++include_directories(BEFORE ${VDK_INCLUDE_DIRS})
+ 
+ find_package(GPM)
+ 
+@@ -135,9 +123,9 @@ set(PKG_CONFIG_LIBS
+ 
+ install (TARGETS vwm DESTINATION bin)
+ install (TARGETS vwm-msg DESTINATION bin)
+-install (TARGETS vwmterm DESTINATION lib/vwm/)
+-install (TARGETS vwmprint DESTINATION lib/vwm/)
+-install (TARGETS vwmfont DESTINATION lib/vwm/)
++install (TARGETS vwmterm DESTINATION ${CMAKE_INSTALL_LIBDIR}/vwm/)
++install (TARGETS vwmprint DESTINATION ${CMAKE_INSTALL_LIBDIR}/vwm/)
++install (TARGETS vwmfont DESTINATION ${CMAKE_INSTALL_LIBDIR}/vwm/)
+ 
+ # dtach session launchers -- PROGRAMS installs them with the execute bit
+ # set, alongside the vwm binary so they share its PATH (and tab-complete

--- a/app-misc/vwm/metadata.xml
+++ b/app-misc/vwm/metadata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>maintainer@example.invalid</email>
+		<name>Overlay maintainer</name>
+	</maintainer>
+	<use>
+		<flag name="dtach">Install app-misc/dtach for the bundled vwm-start and vwm-resume helpers</flag>
+		<flag name="gpm">Enable mouse support through sys-libs/gpm</flag>
+		<flag name="xclip">Install x11-misc/xclip for X11 clipboard integration</flag>
+	</use>
+	<upstream>
+		<remote-id type="github">TragicWarrior/vwm</remote-id>
+		<bugs-to>https://github.com/TragicWarrior/vwm/issues</bugs-to>
+	</upstream>
+</pkgmetadata>

--- a/app-misc/vwm/vwm-9999.ebuild
+++ b/app-misc/vwm/vwm-9999.ebuild
@@ -1,0 +1,90 @@
+EAPI=8
+
+inherit cmake git-r3
+
+DESCRIPTION="Virtual window manager for the terminal"
+HOMEPAGE="https://github.com/TragicWarrior/vwm"
+EGIT_REPO_URI="https://github.com/TragicWarrior/vwm.git"
+
+LICENSE="GPL-2+ LGPL-2.1+ BSD BitstreamVera"
+SLOT="0"
+KEYWORDS=""
+IUSE="dtach gpm xclip"
+
+DEPEND="
+	>=dev-libs/libviper-7.2.0
+	media-libs/freetype
+	net-print/cups
+	sys-libs/ncurses:0=[unicode]
+	sys-libs/zlib
+	gpm? ( sys-libs/gpm )
+"
+RDEPEND="
+	${DEPEND}
+	dtach? ( app-misc/dtach )
+	xclip? ( x11-misc/xclip )
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-9999-system-libraries.patch"
+)
+
+src_unpack() {
+	EGIT_REPO_URI="https://github.com/TragicWarrior/vwm.git"
+	EGIT_CHECKOUT_DIR="${S}"
+	git-r3_src_unpack
+
+	# TragicWarrior/libvterm is unrelated to Gentoo's dev-libs/libvterm,
+	# despite installing the same library/header names.  Keep it private to
+	# this build so both implementations can coexist on a Gentoo system.
+	EGIT_REPO_URI="https://github.com/TragicWarrior/libvterm.git"
+	EGIT_CHECKOUT_DIR="${WORKDIR}/libvterm"
+	git-r3_src_unpack
+}
+
+src_prepare() {
+	cmake_src_prepare
+
+	# Respect the user's optimisation flags when building the private
+	# libvterm copy; upstream otherwise appends -O2 after CFLAGS.
+	sed -i \
+		-e 's/ -O2 -std=c99 -Wall -fPIC -fno-plt/ -std=c99 -Wall -fPIC/' \
+		"${WORKDIR}/libvterm/CMakeLists.txt" || die
+}
+
+src_configure() {
+	# Configure the conflicting libvterm implementation separately and only
+	# consume its static archive.  Nothing from it is installed system-wide.
+	(
+		S="${WORKDIR}/libvterm"
+		BUILD_DIR="${WORKDIR}/libvterm-build"
+		local mycmakeargs=(
+			-DDEFINE_CURSES=OFF
+			-DENABLE_BACKTRACE=OFF
+			-DBUILD_TESTS=OFF
+		)
+		cmake_src_configure
+	)
+
+	local mycmakeargs=(
+		-DCMAKE_DISABLE_FIND_PACKAGE_GPM="$(usex gpm OFF ON)"
+		-DCMAKE_INSTALL_LIBDIR="$(get_libdir)"
+		-DVTERM_INCLUDE_DIR="${WORKDIR}/libvterm"
+		-DVTERM_LIBRARY="${WORKDIR}/libvterm-build/libvterm.a"
+	)
+	cmake_src_configure
+}
+
+src_compile() {
+	(
+		BUILD_DIR="${WORKDIR}/libvterm-build"
+		cmake_build vterm-static
+	)
+
+	cmake_src_compile
+}
+
+src_install() {
+	cmake_src_install
+	dodoc README.md CHANGELOG NEWS.md
+}

--- a/app-misc/vwm/vwm-9999.ebuild
+++ b/app-misc/vwm/vwm-9999.ebuild
@@ -1,3 +1,6 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
 EAPI=8
 
 inherit cmake git-r3
@@ -6,7 +9,7 @@ DESCRIPTION="Virtual window manager for the terminal"
 HOMEPAGE="https://github.com/TragicWarrior/vwm"
 EGIT_REPO_URI="https://github.com/TragicWarrior/vwm.git"
 
-LICENSE="GPL-2+ LGPL-2.1+ BSD BitstreamVera"
+LICENSE="GPL-2+ LGPL-2.1+ BSD MIT BitstreamVera"
 SLOT="0"
 KEYWORDS=""
 IUSE="dtach gpm xclip"

--- a/dev-libs/libviper/files/libviper-9999-libdir.patch
+++ b/dev-libs/libviper/files/libviper-9999-libdir.patch
@@ -1,0 +1,28 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.10.2)
+ 
+ project(libviper C)
+ 
++include(GNUInstallDirs)
++
+ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -fPIC -DNCURSES_OPAQUE=0")
+ set(PROJECT_DESCRIPTION "A library for developing windowed apps on ncurses")
+ 
+@@ -87,7 +89,7 @@ set(PKG_CONFIG_LIBS
+     "-lvdk"
+ )
+ 
+-install (TARGETS vdk-static vdk-shared DESTINATION lib)
++install (TARGETS vdk-static vdk-shared DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ install (FILES vdk.h vkmio.h DESTINATION include)
+ 
+ # Install pkgconfig files to libdata on BSD, otherwise lib
+@@ -95,7 +97,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "BSD")
+     set(PKG_CONFIG_INSTALL_DIR "libdata/pkgconfig")
+ else()
+-    set(PKG_CONFIG_INSTALL_DIR "lib/pkgconfig")
++    set(PKG_CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+ endif()
+ install (FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}.pc" DESTINATION ${PKG_CONFIG_INSTALL_DIR})
+ 

--- a/dev-libs/libviper/files/libviper-9999-libdir.patch
+++ b/dev-libs/libviper/files/libviper-9999-libdir.patch
@@ -9,8 +9,17 @@
  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -fPIC -DNCURSES_OPAQUE=0")
  set(PROJECT_DESCRIPTION "A library for developing windowed apps on ncurses")
  
-@@ -87,7 +89,7 @@ set(PKG_CONFIG_LIBS
+@@ -84,10 +86,13 @@ SET_TARGET_PROPERTIES(vdk-shared PROPERTIES OUTPUT_NAME vdk CLEAN_DIRECT_OUTPUT
+ set(PKG_CONFIG_LIBS
      "-lvdk"
+ )
++set(PKG_CONFIG_INCLUDEDIR "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
++set(PKG_CONFIG_LIBDIR "${CMAKE_INSTALL_FULL_LIBDIR}")
++set(PKG_CONFIG_CFLAGS "-I${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+ 
+ configure_file(
+   "${CMAKE_CURRENT_SOURCE_DIR}/pkg-config.pc.cmake"
+   "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
  )
  
 -install (TARGETS vdk-static vdk-shared DESTINATION lib)
@@ -18,7 +27,7 @@
  install (FILES vdk.h vkmio.h DESTINATION include)
  
  # Install pkgconfig files to libdata on BSD, otherwise lib
-@@ -95,7 +97,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "BSD")
+@@ -95,7 +100,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "BSD")
      set(PKG_CONFIG_INSTALL_DIR "libdata/pkgconfig")
  else()
 -    set(PKG_CONFIG_INSTALL_DIR "lib/pkgconfig")

--- a/dev-libs/libviper/libviper-9999.ebuild
+++ b/dev-libs/libviper/libviper-9999.ebuild
@@ -1,3 +1,6 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
 EAPI=8
 
 inherit cmake git-r3
@@ -35,27 +38,6 @@ src_install() {
 	if ! use static-libs; then
 		rm "${ED}/usr/$(get_libdir)/libvdk.a" || die
 	fi
-
-	# Upstream's generated pkg-config file leaves includedir/libdir blank.
-	# Install a usable system pkg-config description instead.
-	local private_libs="-lncursesw"
-	use gpm && private_libs+=" -lgpm"
-
-	cat > "${T}/libviper.pc" <<-EOF || die
-		prefix=${EPREFIX}/usr
-		exec_prefix=\${prefix}
-		libdir=\${prefix}/$(get_libdir)
-		includedir=\${prefix}/include
-
-		Name: libviper
-		Description: A library for developing windowed apps on ncurses
-		Version: 7.2.0
-		Libs: -L\${libdir} -lvdk
-		Libs.private: ${private_libs}
-		Cflags: -I\${includedir}
-	EOF
-	insinto "/usr/$(get_libdir)/pkgconfig"
-	doins "${T}/libviper.pc"
 
 	dodoc README.md CHANGELOG
 }

--- a/dev-libs/libviper/libviper-9999.ebuild
+++ b/dev-libs/libviper/libviper-9999.ebuild
@@ -1,0 +1,61 @@
+EAPI=8
+
+inherit cmake git-r3
+
+DESCRIPTION="Ncurses widget toolkit used by VWM"
+HOMEPAGE="https://github.com/TragicWarrior/libviper"
+EGIT_REPO_URI="https://github.com/TragicWarrior/libviper.git"
+
+LICENSE="GPL-2+"
+SLOT="0/7"
+KEYWORDS=""
+IUSE="gpm static-libs"
+
+RDEPEND="
+	sys-libs/ncurses:0=[unicode]
+	gpm? ( sys-libs/gpm )
+"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-9999-libdir.patch"
+)
+
+src_configure() {
+	local mycmakeargs=(
+		-DCMAKE_DISABLE_FIND_PACKAGE_GPM="$(usex gpm OFF ON)"
+	)
+
+	cmake_src_configure
+}
+
+src_install() {
+	cmake_src_install
+
+	if ! use static-libs; then
+		rm "${ED}/usr/$(get_libdir)/libvdk.a" || die
+	fi
+
+	# Upstream's generated pkg-config file leaves includedir/libdir blank.
+	# Install a usable system pkg-config description instead.
+	local private_libs="-lncursesw"
+	use gpm && private_libs+=" -lgpm"
+
+	cat > "${T}/libviper.pc" <<-EOF || die
+		prefix=${EPREFIX}/usr
+		exec_prefix=\${prefix}
+		libdir=\${prefix}/$(get_libdir)
+		includedir=\${prefix}/include
+
+		Name: libviper
+		Description: A library for developing windowed apps on ncurses
+		Version: 7.2.0
+		Libs: -L\${libdir} -lvdk
+		Libs.private: ${private_libs}
+		Cflags: -I\${includedir}
+	EOF
+	insinto "/usr/$(get_libdir)/pkgconfig"
+	doins "${T}/libviper.pc"
+
+	dodoc README.md CHANGELOG
+}

--- a/dev-libs/libviper/metadata.xml
+++ b/dev-libs/libviper/metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>maintainer@example.invalid</email>
+		<name>Overlay maintainer</name>
+	</maintainer>
+	<use>
+		<flag name="gpm">Enable mouse support through sys-libs/gpm</flag>
+	</use>
+	<upstream>
+		<remote-id type="github">TragicWarrior/libviper</remote-id>
+		<bugs-to>https://github.com/TragicWarrior/libviper/issues</bugs-to>
+	</upstream>
+</pkgmetadata>


### PR DESCRIPTION
## Summary

- add `app-misc/vwm-9999` from `TragicWarrior/vwm`
- add the required `dev-libs/libviper-9999` source package
- patch VWM to use the system-installed `libviper` instead of requiring a sibling source checkout
- build TragicWarrior's unrelated `libvterm` privately as a static build dependency, without installing its colliding `libvterm.so`/`vterm.h` over Gentoo's existing `dev-libs/libvterm`
- respect Gentoo libdir handling and provide usable `libviper` pkg-config metadata
- expose optional GPM, xclip and dtach integration as USE flags

## Versioning

Upstream currently identifies master as VWM 6.1.0, but does not publish a `6.1.0` or `v6.1.0` Git tag. This therefore adds a live `9999` ebuild rather than inventing a versioned release tarball.

## Testing

Reviewed against the current upstream CMake build definitions and overlay packaging conventions. A full Gentoo emerge is left to the repository CI because the connected GitHub environment does not provide a Gentoo build root.